### PR TITLE
add support for all paints to Text2D

### DIFF
--- a/src/example/java/tech/fastj/example/bullethell/scenes/LoseScene.java
+++ b/src/example/java/tech/fastj/example/bullethell/scenes/LoseScene.java
@@ -29,7 +29,7 @@ public class LoseScene extends Scene {
 
         loseText = new Text2D("You Lost...", new Pointf(300f, 375f))
                 .setFont(new Font("Consolas", Font.PLAIN, 96))
-                .setColor(Color.red);
+                .setPaint(Color.red);
         deathInfo = new Text2D("You died on wave: " + waveNumber, new Pointf(500f, 400f))
                 .setFont(new Font("Consolas", Font.PLAIN, 16));
 

--- a/src/main/java/tech/fastj/graphics/game/Text2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Text2D.java
@@ -6,6 +6,7 @@ import tech.fastj.math.Pointf;
 import tech.fastj.systems.control.Scene;
 
 import java.awt.Color;
+import java.awt.Paint;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
@@ -22,41 +23,41 @@ import java.util.Objects;
  */
 public class Text2D extends GameObject {
 
-    /** {@link Color} representing the default color value of {@code (0, 0, 0)}. */
-    public static final Color DefaultColor = Color.black;
+    /** {@link Paint} representing the default color value of {@code (0, 0, 0)}. */
+    public static final Paint DefaultPaint = Color.black;
     /** {@link Font} representing the default font of {@code Segoe UI Plain, 12px}. */
     public static final Font DefaultFont = new Font("Segoe UI", Font.PLAIN, 12);
     /** {@code boolean} representing the default "should render" value of {@code true}. */
     public static final boolean DefaultShow = true;
 
     private String text;
-    private Color color;
+    private Paint color;
     private Font font;
     private boolean hasMetrics;
 
     /**
      * {@code Text2D} Constructor that takes in a string of text.
      * <p>
-     * This constructor defaults the color to {@link #DefaultColor}, the font to {@link #DefaultFont}, and sets the
+     * This constructor defaults the color to {@link #DefaultPaint}, the font to {@link #DefaultFont}, and sets the
      * {@code show} boolean to {@link #DefaultShow}.
      *
      * @param setText Sets the displayed text.
      */
     public Text2D(String setText) {
-        this(setText, DefaultColor, DefaultFont, DefaultShow);
+        this(setText, DefaultPaint, DefaultFont, DefaultShow);
     }
 
     /**
      * {@code Text2D} Constructor that takes in a string of text and an initial translation.
      * <p>
-     * This constructor defaults the color to {@link #DefaultColor}, the font to {@link #DefaultFont}, and sets the
+     * This constructor defaults the color to {@link #DefaultPaint}, the font to {@link #DefaultFont}, and sets the
      * {@code show} boolean to {@link #DefaultShow}.
      *
      * @param setText        Sets the displayed text.
      * @param setTranslation Sets the initial x and y translation of the text.
      */
     public Text2D(String setText, Pointf setTranslation) {
-        this(setText, DefaultColor, DefaultFont, DefaultShow);
+        this(setText, DefaultPaint, DefaultFont, DefaultShow);
         setTranslation(setTranslation);
     }
 
@@ -64,15 +65,15 @@ public class Text2D extends GameObject {
      * {@code Text2D} Constructor that takes in a string of text, a color, a font, and a show variable.
      *
      * @param setText  Sets the displayed text.
-     * @param setColor Sets the text's color.
+     * @param setPaint Sets the text's color.
      * @param setFont  Sets the text's font.
      * @param show     Sets whether the text will be drawn to the screen.
      */
-    public Text2D(String setText, Color setColor, Font setFont, boolean show) {
+    public Text2D(String setText, Paint setPaint, Font setFont, boolean show) {
         text = setText;
         font = setFont;
 
-        setColor(setColor);
+        setPaint(setPaint);
         setFont(setFont);
         setShouldRender(show);
     }
@@ -82,12 +83,12 @@ public class Text2D extends GameObject {
      *
      * @param setText        Sets the displayed text.
      * @param setTranslation Sets the initial x and y translation of the text.
-     * @param setColor       Sets the text's color.
+     * @param setPaint       Sets the text's color.
      * @param setFont        Sets the text's font.
      * @param show           Sets whether the text will be drawn to the screen.
      */
-    public Text2D(String setText, Pointf setTranslation, Color setColor, Font setFont, boolean show) {
-        this(setText, setColor, setFont, show);
+    public Text2D(String setText, Pointf setTranslation, Paint setPaint, Font setFont, boolean show) {
+        this(setText, setPaint, setFont, show);
         setTranslation(setTranslation);
     }
 
@@ -99,11 +100,11 @@ public class Text2D extends GameObject {
      * @param setTranslation Sets the initial x and y translation of the text.
      * @param setRotation    Sets the initial rotation of the text.
      * @param setScale       Sets the initial scale of the text.
-     * @param setColor       Sets the text's color.
+     * @param setPaint       Sets the text's color.
      * @param setFont        Sets the text's font.
      * @param show           Sets whether the text will be drawn to the screen.
      */
-    public Text2D(String setText, Pointf setTranslation, float setRotation, Pointf setScale, Color setColor, Font setFont, boolean show) {
+    public Text2D(String setText, Pointf setTranslation, float setRotation, Pointf setScale, Paint setPaint, Font setFont, boolean show) {
         text = setText;
         font = setFont;
 
@@ -111,7 +112,7 @@ public class Text2D extends GameObject {
         setRotation(setRotation);
         setScale(setScale);
 
-        setColor(setColor);
+        setPaint(setPaint);
         setFont(setFont);
         setShouldRender(show);
     }
@@ -139,22 +140,22 @@ public class Text2D extends GameObject {
     }
 
     /**
-     * Gets the {@code Color} of this {@code Text2D}.
+     * Gets the {@code Paint} of this {@code Text2D}.
      *
-     * @return Returns the Color value for this Text2D.
+     * @return Returns the Paint value for this Text2D.
      */
-    public Color getColor() {
+    public Paint getPaint() {
         return color;
     }
 
     /**
-     * Sets the {@code Color} for this {@code Text2D}.
+     * Sets the {@code Paint} for this {@code Text2D}.
      *
-     * @param setColor The new {@code Color} value.
+     * @param setPaint The new {@code Paint} value.
      * @return This instance of the {@code Text2D}, for method chaining.
      */
-    public Text2D setColor(Color setColor) {
-        color = setColor;
+    public Text2D setPaint(Paint setPaint) {
+        color = setPaint;
         return this;
     }
 
@@ -192,17 +193,17 @@ public class Text2D extends GameObject {
 
         AffineTransform oldTransform = (AffineTransform) g.getTransform().clone();
         Font oldFont = g.getFont();
-        Color oldColor = g.getColor();
+        Paint oldPaint = g.getPaint();
 
         g.transform(getTransformation());
         g.setFont(font);
-        g.setColor(color);
+        g.setPaint(color);
 
         g.drawString(text, Pointf.Origin.x, font.getSize2D());
 
         g.setTransform(oldTransform);
         g.setFont(oldFont);
-        g.setColor(oldColor);
+        g.setPaint(oldPaint);
     }
 
     @Override

--- a/src/test/java/unittest/testcases/graphics/game/Text2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Text2DTests.java
@@ -32,7 +32,7 @@ class Text2DTests {
             Text2D text2D = new Text2D(text);
 
             assertEquals(text, text2D.getText(), "The actual text should match the expected text.");
-            assertEquals(Text2D.DefaultColor, text2D.getColor(), "The actual color should match the expected color.");
+            assertEquals(Text2D.DefaultPaint, text2D.getPaint(), "The actual color should match the expected color.");
             assertEquals(Text2D.DefaultFont, text2D.getFont(), "The actual font should match the default font.");
             assertEquals(Text2D.DefaultShow, text2D.shouldRender(), "The actual show variable should match the default show variable.");
         });
@@ -48,7 +48,7 @@ class Text2DTests {
 
             assertEquals(text, text2D.getText(), "The actual text should match the expected text.");
             assertEquals(randomTranslation, text2D.getTranslation(), "The actual translation should match the expected translation.");
-            assertEquals(Text2D.DefaultColor, text2D.getColor(), "The actual color should match the expected color.");
+            assertEquals(Text2D.DefaultPaint, text2D.getPaint(), "The actual color should match the expected color.");
             assertEquals(Text2D.DefaultFont, text2D.getFont(), "The actual font should match the default font.");
             assertEquals(Text2D.DefaultShow, text2D.shouldRender(), "The actual show variable should match the default show variable.");
         });
@@ -68,7 +68,7 @@ class Text2DTests {
 
             assertEquals(text, text2D.getText(), "The actual text should match the expected text.");
             assertEquals(randomTranslation, text2D.getTranslation(), "The actual translation should match the expected translation.");
-            assertEquals(randomColor, text2D.getColor(), "The actual color should match the expected random color.");
+            assertEquals(randomColor, text2D.getPaint(), "The actual color should match the expected random color.");
             assertEquals(randomFont, text2D.getFont(), "The actual font should match the expected random font.");
             assertEquals(randomShouldRender, text2D.shouldRender(), "The actual show variable should match the expected random show variable.");
         });
@@ -95,7 +95,7 @@ class Text2DTests {
             assertEquals(randomRotation, text2D.getRotation(), "The created polygon's rotation should match the randomly generated rotation.");
             assertEquals(expectedNormalizedRotation, text2D.getRotationWithin360(), "The created model's normalized rotation should match the normalized rotation.");
             assertEquals(randomScale, text2D.getScale(), "The created polygon's scaling should match the randomly generated scale.");
-            assertEquals(randomColor, text2D.getColor(), "The actual color should match the expected random color.");
+            assertEquals(randomColor, text2D.getPaint(), "The actual color should match the expected random color.");
             assertEquals(randomFont, text2D.getFont(), "The actual font should match the expected random font.");
             assertEquals(randomShouldRender, text2D.shouldRender(), "The actual show variable should match the expected random show variable.");
         });
@@ -116,7 +116,7 @@ class Text2DTests {
             float expectedNormalizedRotation = randomRotation % 360;
 
             Text2D text2D = (Text2D) new Text2D(text)
-                    .setColor(randomColor)
+                    .setPaint(randomColor)
                     .setFont(randomFont)
                     .setTranslation(randomTranslation)
                     .setRotation(randomRotation)
@@ -128,7 +128,7 @@ class Text2DTests {
             assertEquals(randomRotation, text2D.getRotation(), "The created polygon's rotation should match the randomly generated rotation.");
             assertEquals(expectedNormalizedRotation, text2D.getRotationWithin360(), "The created model's normalized rotation should match the normalized rotation.");
             assertEquals(randomScale, text2D.getScale(), "The created polygon's scaling should match the randomly generated scale.");
-            assertEquals(randomColor, text2D.getColor(), "The actual color should match the expected random color.");
+            assertEquals(randomColor, text2D.getPaint(), "The actual color should match the expected random color.");
             assertEquals(randomFont, text2D.getFont(), "The actual font should match the expected random font.");
             assertEquals(randomShouldRender, text2D.shouldRender(), "The actual show variable should match the expected random show variable.");
         });


### PR DESCRIPTION
Adds support for all `Paint`s to the Text2D class.

## Breaking Changes
- Changed `Text2D#getColor` and `Text2D#setColor` to `Text2D#getPaint` and `Text2D#setPaint`, respectively.
- Changed `Text2D#DefaultColor` to `Text2D#DefaultPaint`