### PR TITLE
Update Camera Transforms to use Transform2D

### DIFF
--- a/src/main/java/tech/fastj/graphics/Camera.java
+++ b/src/main/java/tech/fastj/graphics/Camera.java
@@ -1,6 +1,5 @@
 package tech.fastj.graphics;
 
-import tech.fastj.engine.FastJEngine;
 import tech.fastj.math.Pointf;
 
 import java.awt.geom.AffineTransform;
@@ -42,11 +41,7 @@ public class Camera {
      * @return The centerpoint, as a {@code Pointf}.
      */
     public Pointf getCenter() {
-        if (FastJEngine.getDisplay() == null) {
-            return getTranslation().copy();
-        } else {
-            return Pointf.add(FastJEngine.getDisplay().getScreenCenter(), getTranslation());
-        }
+        return getTranslation().copy();
     }
 
     /**
@@ -201,11 +196,7 @@ public class Camera {
      * @param rotationMod float parameter that the {@code Camera} will be rotated by.
      */
     public void rotate(float rotationMod) {
-        if (FastJEngine.getDisplay() == null) {
-            rotate(rotationMod, Pointf.Origin);
-        } else {
-            rotate(rotationMod, FastJEngine.getDisplay().getScreenCenter());
-        }
+        rotate(rotationMod, Pointf.Origin);
     }
 
     /**

--- a/src/main/java/tech/fastj/graphics/Camera.java
+++ b/src/main/java/tech/fastj/graphics/Camera.java
@@ -1,6 +1,6 @@
 package tech.fastj.graphics;
 
-import tech.fastj.math.Maths;
+import tech.fastj.engine.FastJEngine;
 import tech.fastj.math.Pointf;
 
 import java.awt.geom.AffineTransform;
@@ -14,134 +14,244 @@ import java.util.Objects;
  */
 public class Camera {
 
-    /** {@link Pointf} representing a default translation of {@code (0f, 0f)}. */
-    public static final Pointf DefaultTranslation = Pointf.Origin.copy();
-    /** {@code float} representing a default rotation value of {@code 0f}. */
-    public static final float DefaultRotation = 0f;
-
     /** A camera with no transformations. */
     public static final Camera Default = new Camera();
 
-    private final Pointf translation;
-    private float rotation;
+    private final Transform2D transform;
 
     /** Constructs a {@code Camera} with default transformations. */
     public Camera() {
-        this(DefaultTranslation.copy(), DefaultRotation);
-    }
-
-    /**
-     * Constructs a {@code Camera} with translation set to the specified value, and rotation set to 0.
-     *
-     * @param setTranslation Sets the translation of this {@code Camera}.
-     */
-    public Camera(Pointf setTranslation) {
-        this(setTranslation, DefaultRotation);
-    }
-
-    /**
-     * Constructs a {@code Camera} with rotation set to the specified value, and translation set to 0.
-     *
-     * @param setRotation Sets the rotation of this {@code Camera}.
-     */
-    public Camera(float setRotation) {
-        this(DefaultTranslation, setRotation);
+        this(Transform2D.DefaultTranslation, Transform2D.DefaultRotation, Transform2D.DefaultScale);
     }
 
     /**
      * Constructs a {@code Camera} with translation and rotation set to the specified values.
      *
-     * @param setTranslation Sets the translation of this {@code Camera}.
-     * @param setRotation    Sets the rotation of this {@code Camera}.
+     * @param setTranslation {@code Pointf} parameter that the {@code Camera}'s translation will be set to.
+     * @param setRotation    float parameter that the {@code Camera}'s rotation will be set to.
+     * @param setScale       {@code Pointf} parameter that the {@code Camera}'s scale will be set to.
      */
-    public Camera(Pointf setTranslation, float setRotation) {
-        translation = setTranslation;
-        rotation = setRotation;
+    public Camera(Pointf setTranslation, float setRotation, Pointf setScale) {
+        transform = new Transform2D();
+        setTransform(setTranslation, setRotation, setScale);
     }
 
     /**
-     * Applies a modifier to the {@code Camera}'s rotation.
+     * Gets the centerpoint of the {@code Camera}.
      *
-     * @param rotationMod Modifier for the {@code Camera}'s rotation.
+     * @return The centerpoint, as a {@code Pointf}.
      */
-    public void rotate(float rotationMod) {
-        rotation += rotationMod;
+    public Pointf getCenter() {
+        if (FastJEngine.getDisplay() == null) {
+            return getTranslation().copy();
+        } else {
+            return Pointf.add(FastJEngine.getDisplay().getScreenCenter(), getTranslation());
+        }
     }
 
     /**
-     * Applies a modifier to the {@code Camera}'s translation.
+     * Gets the {@code Camera}'s translation.
      *
-     * @param translationMod {@code Pointf} value which the {@code Camera}'s x and y location will be modified by.
-     */
-    public void translate(Pointf translationMod) {
-        translation.add(translationMod);
-    }
-
-    /**
-     * Gets the {@code Camera}'s current rotation.
-     *
-     * @return The {@code Camera}'s current rotation.
-     */
-    public double getRotation() {
-        return rotation;
-    }
-
-    /**
-     * Gets the {@code Camera}'s current translation.
-     *
-     * @return The {@code Camera}'s current translation.
+     * @return A {@code Pointf} that represents the current translation of the {@code Camera}.
      */
     public Pointf getTranslation() {
-        return translation;
+        return transform.getTranslation();
     }
 
     /**
-     * Gets the transformation of this {@code Camera} object as an {@code AffineTransform}.
+     * Sets the {@code Camera}'s translation to the specified value.
      *
-     * @return The overall transformation of the {@code Camera} object as an {@code AffineTransform} value.
+     * @param setTranslation {@code Pointf} parameter that the {@code Camera}'s translation will be set to.
+     * @return The {@code Camera}, for method chaining.
+     */
+    public Camera setTranslation(Pointf setTranslation) {
+        if (getTranslation().equals(setTranslation)) {
+            return this;
+        }
+
+        transform.setTranslation(setTranslation);
+        return this;
+    }
+
+    /**
+     * Gets the {@code Camera}'s rotation.
+     *
+     * @return A float that represents the current rotation of the {@code Camera}.
+     */
+    public float getRotation() {
+        return transform.getRotation();
+    }
+
+    /**
+     * Sets the {@code Camera}'s rotation to the specified value.
+     *
+     * @param setRotation float parameter that the {@code Camera}'s rotation will be set to.
+     * @return The {@code Camera}, for method chaining.
+     */
+    public Camera setRotation(float setRotation) {
+        if (getRotation() == setRotation) {
+            return this;
+        }
+
+        transform.setRotation(setRotation);
+        return this;
+    }
+
+    /**
+     * Gets the {@code Camera}'s scale.
+     *
+     * @return A {@code Pointf} that represents the current scale of the object.
+     */
+    public Pointf getScale() {
+        return transform.getScale();
+    }
+
+    /**
+     * Sets the {@code Camera}'s scale to the specified value.
+     *
+     * @param setScale {@code Pointf} parameter that the {@code Camera}'s scale will be set to.
+     * @return The {@code Camera}, for method chaining.
+     */
+    public Camera setScale(Pointf setScale) {
+        if (getScale().equals(setScale)) {
+            return this;
+        }
+
+        transform.setScale(setScale);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Camera}'s translation, rotation, and scale to the specified values.
+     *
+     * @param setTranslation {@code Pointf} parameter that the {@code Camera}'s translation will be set to.
+     * @param setRotation    float parameter that the {@code Camera}'s rotation will be set to.
+     * @param setScale       {@code Pointf} parameter that the {@code Camera}'s scale will be set to.
+     * @return The {@code Camera}, for method chaining.
+     */
+    public Camera setTransform(Pointf setTranslation, float setRotation, Pointf setScale) {
+        setTranslation(setTranslation);
+        setRotation(setRotation);
+        setScale(setScale);
+        return this;
+    }
+
+    /**
+     * Translates the {@code Camera}'s position by the specified translation.
+     *
+     * @param translationMod {@code Pointf} parameter that the {@code Camera}'s x and y location will be translated by.
+     */
+    public void translate(Pointf translationMod) {
+        if (Transform2D.DefaultTranslation.equals(translationMod)) {
+            return;
+        }
+
+        transform.translate(translationMod);
+    }
+
+    /**
+     * Rotates the {@code Camera} in the direction of the specified rotation, about the specified centerpoint.
+     *
+     * @param rotationMod float parameter that the {@code Camera} will be rotated by.
+     * @param centerpoint {@code Pointf} parameter that the {@code Camera} will be rotated about.
+     */
+    public void rotate(float rotationMod, Pointf centerpoint) {
+        if (rotationMod == Transform2D.DefaultRotation) {
+            return;
+        }
+
+        transform.rotate(rotationMod, centerpoint);
+    }
+
+    /**
+     * Scales the {@code Camera} in by the amount specified in the specified scale, from the specified centerpoint.
+     *
+     * @param scaleMod    {@code Pointf} parameter that the {@code Camera}'s width and height will be scaled by.
+     * @param centerpoint {@code Pointf} parameter that the {@code Camera} will be scaled about.
+     */
+    public void scale(Pointf scaleMod, Pointf centerpoint) {
+        if (Transform2D.DefaultScale.equals(scaleMod)) {
+            return;
+        }
+
+        transform.scale(scaleMod, centerpoint);
+    }
+
+    /**
+     * Gets the rotation, normalized to be within a range of {@code (-360, 360)}.
+     *
+     * @return The normalized rotation.
+     */
+    public float getRotationWithin360() {
+        return transform.getRotationWithin360();
+    }
+
+    /**
+     * Gets the entire transformation of the {@code Camera}.
+     *
+     * @return The transformation, as an {@link AffineTransform}.
      */
     public AffineTransform getTransformation() {
-        AffineTransform at = new AffineTransform();
+        return transform.getAffineTransform();
+    }
 
-        if (rotation != Camera.DefaultRotation) {
-            at.rotate(Math.toRadians(rotation));
+    /**
+     * Rotates the {@code Camera} in the direction of the specified rotation, about its center.
+     *
+     * @param rotationMod float parameter that the {@code Camera} will be rotated by.
+     */
+    public void rotate(float rotationMod) {
+        if (FastJEngine.getDisplay() == null) {
+            rotate(rotationMod, Pointf.Origin);
+        } else {
+            rotate(rotationMod, FastJEngine.getDisplay().getScreenCenter());
         }
-        if (translation.x != Camera.DefaultTranslation.x || translation.y != Camera.DefaultTranslation.y) {
-            at.translate(translation.x, translation.y);
-        }
+    }
 
-        return at;
+    /**
+     * Scales the {@code Camera} in by the amount specified in the specified scale, about its center.
+     *
+     * @param scaleXY float parameter that the {@code Camera} will be scaled by, acting as both the x and y values.
+     */
+    public void scale(float scaleXY) {
+        scale(new Pointf(scaleXY), getCenter());
+    }
+
+    /**
+     * Scales the {@code Camera} in by the amount specified in the specified scale, about its center.
+     *
+     * @param scaleMod {@code Pointf} parameter that the {@code Camera} will be scaled by, based on its x and y values.
+     */
+    public void scale(Pointf scaleMod) {
+        scale(scaleMod, getCenter());
     }
 
     /** Resets the camera's transformation to the default. */
     public void reset() {
-        translation.reset();
-        rotation = Camera.DefaultRotation;
+        transform.reset();
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
-
-        Camera camera = (Camera) o;
-        return Maths.floatEquals(camera.rotation, rotation) && Objects.equals(translation, camera.translation);
+        Camera camera = (Camera) other;
+        return camera.transform.equals(transform);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(translation, rotation);
+        return Objects.hash(transform);
     }
 
     @Override
     public String toString() {
         return "Camera{" +
-                "translation=" + translation +
-                ", rotation=" + rotation +
+                "transform=" + transform +
                 '}';
     }
 }

--- a/src/main/java/tech/fastj/graphics/Display.java
+++ b/src/main/java/tech/fastj/graphics/Display.java
@@ -225,6 +225,15 @@ public class Display {
     }
 
     /**
+     * Gets the centerpoint of the {@code Display}'s internal resolution.
+     *
+     * @return The centerpoint of the internal resolution as a {@code Pointf}.
+     */
+    public Pointf getScreenCenter() {
+        return Pointf.divide(internalResolution.asPointf(), 2f);
+    }
+
+    /**
      * Gets the value that determines whether the {@code Display} is in full-screen mode.
      *
      * @return The boolean that determines whether the {@code Display} is in full-screen mode.

--- a/src/main/java/tech/fastj/graphics/Transform2D.java
+++ b/src/main/java/tech/fastj/graphics/Transform2D.java
@@ -4,6 +4,7 @@ import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 
 import java.awt.geom.AffineTransform;
+import java.util.Objects;
 
 /** Convenience class for storing/performing 2D transformations using {@link AffineTransform}. */
 public class Transform2D {
@@ -117,5 +118,33 @@ public class Transform2D {
 
     public void resetScale() {
         scaleTransform.setToIdentity();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        Transform2D transform2D = (Transform2D) other;
+        return Maths.floatEquals(rotation, transform2D.rotation)
+                && getTranslation().equals(transform2D.getTranslation())
+                && getScale().equals(transform2D.getScale());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(translationTransform, rotationTransform, scaleTransform, lastRotationPoint, lastScalePoint, rotation);
+    }
+
+    @Override
+    public String toString() {
+        return "Transform2D{" +
+                "translation=" + getTranslation() +
+                ", rotation=" + rotation +
+                ", scale=" + getScale() +
+                '}';
     }
 }

--- a/src/test/java/unittest/testcases/graphics/CameraTests.java
+++ b/src/test/java/unittest/testcases/graphics/CameraTests.java
@@ -3,6 +3,7 @@ package unittest.testcases.graphics;
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 import tech.fastj.graphics.Camera;
+import tech.fastj.graphics.Transform2D;
 
 import java.awt.geom.AffineTransform;
 
@@ -19,29 +20,17 @@ class CameraTests {
     }
 
     @Test
-    void createCamera_withTranslationPointf_andDefaultRotation_shouldMatchExpected() {
-        Pointf randomTranslation = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
-        Camera camera = new Camera(randomTranslation);
-
-        assertEquals(randomTranslation, camera.getTranslation(), "The created camera's translation should match the expected translation.");
-    }
-
-    @Test
-    void createCamera_withDefaultTranslation_andRotationFloat_shouldMatchExpected() {
-        float randomRotation = Maths.random(-50f, 50f);
-        Camera camera = new Camera(randomRotation);
-
-        assertEquals(randomRotation, camera.getRotation(), "The created camera's rotation should match the expected rotation.");
-    }
-
-    @Test
-    void createCamera_withTranslationPointf_andRotationFloat_shouldMatchExpected() {
+    void createCamera_withTranslationPointf_andRotationFloat_andScalePointf_shouldMatchExpected() {
         Pointf randomTranslation = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
         float randomRotation = Maths.random(-50f, 50f);
-        Camera camera = new Camera(randomTranslation, randomRotation);
+        float expectedNormalizedRotation = randomRotation % 360;
+        Pointf randomScale = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
+
+        Camera camera = new Camera(randomTranslation, randomRotation, randomScale);
 
         assertEquals(randomTranslation, camera.getTranslation(), "The created camera's translation should match the expected translation.");
         assertEquals(randomRotation, camera.getRotation(), "The created camera's rotation should match the expected rotation.");
+        assertEquals(expectedNormalizedRotation, camera.getRotationWithin360(), "The created camera's normalized rotation should match the normalized rotation.");
     }
 
     @Test
@@ -60,7 +49,6 @@ class CameraTests {
         expectedTransform.translate(randomTranslation1.x + randomTranslation2.x + randomTranslation3.x, randomTranslation1.y + randomTranslation2.y + randomTranslation3.y);
 
         assertEquals(expectedTranslation, camera.getTranslation(), "After translating the camera 3 times, the camera's translation should match the expected translation.");
-        assertEquals(expectedTransform, camera.getTransformation(), "After translating the camera 3 times, the camera's transform should match the expected transform.");
     }
 
     @Test
@@ -74,11 +62,30 @@ class CameraTests {
         camera.rotate(randomRotation2);
         camera.rotate(randomRotation3);
         float expectedRotation = randomRotation1 + randomRotation2 + randomRotation3;
+        float expectedNormalizedRotation = expectedRotation % 360;
 
         AffineTransform expectedTransform = new AffineTransform();
         expectedTransform.rotate(Math.toRadians(randomRotation1 + randomRotation2 + randomRotation3));
 
         assertEquals(expectedRotation, camera.getRotation(), "After rotating the camera 3 times, the camera's rotation should match the expected rotation.");
-        assertEquals(expectedTransform, camera.getTransformation(), "After rotating the camera 3 times, the camera's transform should match the expected transform.");
+        assertEquals(expectedNormalizedRotation, camera.getRotationWithin360(), "The created camera's normalized rotation should match the normalized rotation.");
+    }
+
+    @Test
+    void checkCameraScale_shouldMatchExpected() {
+        Camera camera = new Camera();
+
+        Pointf randomScale1 = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
+        Pointf randomScale2 = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
+        Pointf randomScale3 = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
+        camera.scale(randomScale1);
+        camera.scale(randomScale2);
+        camera.scale(randomScale3);
+        Pointf expectedScale = Pointf.add(randomScale1, randomScale2).add(randomScale3).add(Transform2D.DefaultScale);
+
+        AffineTransform expectedTransform = new AffineTransform();
+        expectedTransform.scale(randomScale1.x + randomScale2.x + randomScale3.x, randomScale1.y + randomScale2.y + randomScale3.y);
+
+        assertEquals(expectedScale, camera.getScale(), "After scaling the camera 3 times, the camera's scale should match the expected scale.");
     }
 }


### PR DESCRIPTION
# Update Camera Transforms to use Transform2D
Resolves #12

## Additions
- Added `Transform2D` instance and methods (similar to those in `Drawable`) for transform manipulation
- Added `Display#getScreenCenter` to aid in determining the center of the camera
- Added `equals, hashCode, toString` methods to `Transform2D`


## Breaking Changes
- Replaced `Camera` constructors with only an empty constructor and a constructor that sets the initial transform.