### PR TITLE
Re-add templates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ A few common dependencies are provided below:
 There are many different ways to learn FastJ -- namely the API documentation, the examples, and the tutorials on the main website.
 
 
+### Template Projects
+Check out these template projects for FastJ! They're the fastest way to jump right into using FastJ.
+
+- Java: https://github.com/lucasstarsz/fastj-java-template
+- Kotlin: https://github.com/lucasstarsz/fastj-kotlin-template
+- Groovy: https://github.com/lucasstarsz/fastj-groovy-template
+
+
 ### Tutorials
 [FastJ provides article tutorials][FastJ-Tutorials] on its website to accommodate as many types of developers as possible. From beginners to experts, the website tutorials are written to give enough information to satisfy anyone willing to learn!
 


### PR DESCRIPTION
# Re-add templates to README
In a [recent commit](https://github.com/fastjengine/FastJ/commit/59ab49b2fcadca65ff49f539a05666a7743fdb75), the template links were overwritten and removed from the engine's main README file by accident. This PR re-adds them to the README, in the README's current style.


## Additions
- added templates to README, in the **Learning FastJ** section.

