### PR TITLE
Bump outward-facing snapshot to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group('io.github.lucasstarsz.fastj')
-version('1.5.0-SNAPSHOT')
+version('1.6.0-SNAPSHOT')
 description('An open source, Java-based 2D game engine.')
 
 import org.gradle.api.internal.tasks.testing.results.DefaultTestResult


### PR DESCRIPTION
# Bump outward-facing snapshot to 1.6.0
Resolves #81.

## Other Changes
- bumped build.gradle snapshot version to 1.6.0
