### PR TITLE
Audio 3: Add support for loading files via URL

### DIFF
--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -8,7 +8,10 @@ import tech.fastj.systems.fio.FileUtil;
 
 import javax.sound.sampled.*;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -67,6 +70,18 @@ public class AudioManager {
     }
 
     /**
+     * Loads a {@link MemoryAudio} object at the specified path into memory.
+     *
+     * @param audioPath The path of the {@code MemoryAudio} object to load.
+     * @return The created {@link MemoryAudio} instance.
+     */
+    public static MemoryAudio loadMemoryAudio(URL audioPath) {
+        MemoryAudio audio = new MemoryAudio(audioPath);
+        MemoryAudioFiles.put(audio.getID(), audio);
+        return audio;
+    }
+
+    /**
      * Loads all {@link MemoryAudio} objects at the specified paths into memory.
      *
      * @param audioPaths The paths of the {@code MemoryAudio} objects to load.
@@ -91,6 +106,18 @@ public class AudioManager {
      * @return The created {@link StreamedAudio} instance.
      */
     public static StreamedAudio loadStreamedAudio(Path audioPath) {
+        StreamedAudio audio = new StreamedAudio(audioPath);
+        StreamedAudioFiles.put(audio.getID(), audio);
+        return audio;
+    }
+
+    /**
+     * Loads a {@link StreamedAudio} object at the specified path into memory.
+     *
+     * @param audioPath The path of the {@code StreamedAudio} object to load.
+     * @return The created {@link StreamedAudio} instance.
+     */
+    public static StreamedAudio loadStreamedAudio(URL audioPath) {
         StreamedAudio audio = new StreamedAudio(audioPath);
         StreamedAudioFiles.put(audio.getID(), audio);
         return audio;
@@ -221,6 +248,25 @@ public class AudioManager {
             FastJEngine.error(
                     CrashMessages.theGameCrashed("an audio file reading error."),
                     new UnsupportedAudioFileException(audioPath.toAbsolutePath() + " is of an unsupported file format \"" + FileUtil.getFileExtension(audioPath) + "\".")
+            );
+        }
+
+        return null;
+    }
+
+    /** Safely generates an {@link AudioInputStream} object, crashing the engine if something goes wrong. */
+    static AudioInputStream newAudioStream(URL audioPath) {
+        try {
+            return AudioSystem.getAudioInputStream(audioPath);
+        } catch (IOException exception) {
+            FastJEngine.error(
+                    CrashMessages.theGameCrashed("an I/O error while loading sound."),
+                    exception
+            );
+        } catch (UnsupportedAudioFileException exception) {
+            FastJEngine.error(
+                    CrashMessages.theGameCrashed("an audio file reading error."),
+                    new UnsupportedAudioFileException(audioPath.getPath() + " is of an unsupported file format \"" + FileUtil.getFileExtension(Path.of(audioPath.getPath())) + "\".")
             );
         }
 

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -12,7 +12,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -8,10 +8,8 @@ import tech.fastj.systems.fio.FileUtil;
 
 import javax.sound.sampled.*;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -98,6 +98,24 @@ public class AudioManager {
     }
 
     /**
+     * Loads all {@link MemoryAudio} objects at the specified URLs into memory.
+     *
+     * @param audioPaths The URLs of the {@code MemoryAudio} objects to load.
+     * @return The created {@link MemoryAudio} instances.
+     */
+    public static MemoryAudio[] loadMemoryAudio(URL... audioPaths) {
+        MemoryAudio[] audioInstances = new MemoryAudio[audioPaths.length];
+
+        for (int i = 0; i < audioPaths.length; i++) {
+            MemoryAudio audio = new MemoryAudio(audioPaths[i]);
+            MemoryAudioFiles.put(audio.getID(), audio);
+            audioInstances[i] = audio;
+        }
+
+        return audioInstances;
+    }
+
+    /**
      * Loads a {@link StreamedAudio} object at the specified path into memory.
      *
      * @param audioPath The path of the {@code StreamedAudio} object to load.
@@ -128,6 +146,24 @@ public class AudioManager {
      * @return The created {@link StreamedAudio} instances.
      */
     public static StreamedAudio[] loadStreamedAudio(Path... audioPaths) {
+        StreamedAudio[] audioInstances = new StreamedAudio[audioPaths.length];
+
+        for (int i = 0; i < audioPaths.length; i++) {
+            StreamedAudio audio = new StreamedAudio(audioPaths[i]);
+            StreamedAudioFiles.put(audio.getID(), audio);
+            audioInstances[i] = audio;
+        }
+
+        return audioInstances;
+    }
+
+    /**
+     * Loads all {@link StreamedAudio} objects at the specified URLs into memory.
+     *
+     * @param audioPaths The URLs of the {@code StreamedAudio} objects to load.
+     * @return The created {@link StreamedAudio} instances.
+     */
+    public static StreamedAudio[] loadStreamedAudio(URL... audioPaths) {
         StreamedAudio[] audioInstances = new StreamedAudio[audioPaths.length];
 
         for (int i = 0; i < audioPaths.length; i++) {

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -254,6 +255,25 @@ public class AudioManager {
 
         audioEventExecutor.shutdownNow();
         audioEventExecutor = Executors.newWorkStealingPool();
+    }
+
+    static Path pathFromURL(URL audioPath) {
+        String urlPath = audioPath.getPath();
+        String urlProtocol = audioPath.getProtocol();
+
+        if (urlPath.startsWith(urlProtocol)) {
+            return Path.of(urlPath.substring(urlProtocol.length()));
+        } else if (urlPath.startsWith("file:///")) {
+            return Path.of(urlPath.substring(8));
+        } else {
+            // In this case, the file path starts with "/" which may need to be removed depending
+            // on the operating system.
+            return Path.of(
+                    urlPath.startsWith("/") && !System.getProperty("os.name").startsWith("Mac")
+                    ? urlPath.replaceFirst("/*+", "")
+                    : urlPath
+            );
+        }
     }
 
     /** Safely generates a {@link Clip} object, crashing the engine if something goes wrong. */

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -102,7 +102,7 @@ public class MemoryAudio implements Audio {
             this.audioPath = Path.of(urlPath.substring(8));
         } else {
             // In this case, the file starts with "/".
-            this.audioPath = Path.of(urlPath.replaceFirst("(/?)*", ""));
+            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
         }
 
         this.id = UUID.randomUUID().toString();

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -93,25 +93,27 @@ public class MemoryAudio implements Audio {
      * @param audioPath The path of the audio to use.
      */
     MemoryAudio(URL audioPath) {
-        String urlPath = audioPath.getPath();
-        String urlProtocol = audioPath.getProtocol();
-
-        if (urlPath.startsWith(urlProtocol)) {
-            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
-        } else if (urlPath.startsWith("file:///")) {
-            this.audioPath = Path.of(urlPath.substring(8));
-        } else {
-            // In this case, the file starts with "/".
-            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
-        }
-
         this.id = UUID.randomUUID().toString();
 
         loopStart = LoopFromStart;
         loopEnd = LoopAtEnd;
 
         clip = Objects.requireNonNull(AudioManager.newClip());
-        audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
+
+        String urlPath = audioPath.getPath();
+        String urlProtocol = audioPath.getProtocol();
+
+        if (urlPath.startsWith(urlProtocol)) {
+            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
+        } else if (urlPath.startsWith("file:///")) {
+            this.audioPath = Path.of(urlPath.substring(8));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
+        } else {
+            // In this case, the file starts with "/".
+            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
+        }
 
         audioEventListener = new AudioEventListener(this);
         currentPlaybackState = PlaybackState.Stopped;

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -93,7 +93,18 @@ public class MemoryAudio implements Audio {
      * @param audioPath The path of the audio to use.
      */
     MemoryAudio(URL audioPath) {
-        this.audioPath = Path.of(audioPath.getPath().substring(8));
+        String urlPath = audioPath.getPath();
+        String urlProtocol = audioPath.getProtocol();
+
+        if (urlPath.startsWith(urlProtocol)) {
+            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
+        } else if (urlPath.startsWith("file:///")) {
+            this.audioPath = Path.of(urlPath.substring(8));
+        } else {
+            // In this case, the file starts with "/".
+            this.audioPath = Path.of(urlPath.replaceFirst("(/?)*", ""));
+        }
+
         this.id = UUID.randomUUID().toString();
 
         loopStart = LoopFromStart;

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -4,6 +4,7 @@ import tech.fastj.systems.audio.state.PlaybackState;
 
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.Clip;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
@@ -73,6 +74,26 @@ public class MemoryAudio implements Audio {
      */
     MemoryAudio(Path audioPath) {
         this.audioPath = audioPath;
+        this.id = UUID.randomUUID().toString();
+
+        loopStart = LoopFromStart;
+        loopEnd = LoopAtEnd;
+
+        clip = Objects.requireNonNull(AudioManager.newClip());
+        audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
+
+        audioEventListener = new AudioEventListener(this);
+        currentPlaybackState = PlaybackState.Stopped;
+        previousPlaybackState = PlaybackState.Stopped;
+    }
+
+    /**
+     * Constructs the {@code MemoryAudio} object with the given URL.
+     *
+     * @param audioPath The path of the audio to use.
+     */
+    MemoryAudio(URL audioPath) {
+        this.audioPath = Path.of(audioPath.getPath().substring(8));
         this.id = UUID.randomUUID().toString();
 
         loopStart = LoopFromStart;

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -103,15 +103,11 @@ public class MemoryAudio implements Audio {
         String urlPath = audioPath.getPath();
         String urlProtocol = audioPath.getProtocol();
 
-        if (urlPath.startsWith(urlProtocol)) {
-            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
-            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
-        } else if (urlPath.startsWith("file:///")) {
-            this.audioPath = Path.of(urlPath.substring(8));
+        this.audioPath = AudioManager.pathFromURL(audioPath);
+
+        if (urlPath.startsWith(urlProtocol) || urlPath.startsWith("file:///")) {
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else {
-            // In this case, the file starts with "/".
-            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -94,7 +94,7 @@ public class StreamedAudio implements Audio {
             this.audioPath = Path.of(urlPath.substring(8));
         } else {
             // In this case, the file starts with "/".
-            this.audioPath = Path.of(urlPath.replaceFirst("(/?)*", ""));
+            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
         }
 
         this.id = UUID.randomUUID().toString();

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -103,6 +103,8 @@ public class StreamedAudio implements Audio {
                     ? urlPath.replaceFirst("/*+", "")
                     : urlPath
             );
+            System.err.println(audioPath);
+            System.err.println(this.audioPath);
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -99,7 +99,7 @@ public class StreamedAudio implements Audio {
         } else {
             // In this case, the file may start with "/".
             this.audioPath = Path.of(
-                    urlPath.startsWith("/") && !System.getProperty("os.name").startsWith("mac")
+                    urlPath.startsWith("/") && !System.getProperty("os.name").startsWith("Mac")
                     ? urlPath.replaceFirst("/*+", "")
                     : urlPath
             );

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -97,8 +97,8 @@ public class StreamedAudio implements Audio {
             this.audioPath = Path.of(urlPath.substring(8));
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else {
-            // In this case, the file starts with "/".
-            this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
+            // In this case, the file may start with "/".
+            this.audioPath = Path.of(urlPath.startsWith("/") ? urlPath.replaceFirst("/*+", "") : urlPath);
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -85,21 +85,23 @@ public class StreamedAudio implements Audio {
      * @param audioPath The path of the audio to use.
      */
     StreamedAudio(URL audioPath) {
+        this.id = UUID.randomUUID().toString();
+
         String urlPath = audioPath.getPath();
         String urlProtocol = audioPath.getProtocol();
 
         if (urlPath.startsWith(urlProtocol)) {
             this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else if (urlPath.startsWith("file:///")) {
             this.audioPath = Path.of(urlPath.substring(8));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else {
             // In this case, the file starts with "/".
             this.audioPath = Path.of(urlPath.replaceFirst("/*+", ""));
+            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 
-        this.id = UUID.randomUUID().toString();
-
-        audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         sourceDataLine = Objects.requireNonNull(AudioManager.newSourceDataLine(audioInputStream.getFormat()));
 
         try {

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -90,21 +90,11 @@ public class StreamedAudio implements Audio {
         String urlPath = audioPath.getPath();
         String urlProtocol = audioPath.getProtocol();
 
-        if (urlPath.startsWith(urlProtocol)) {
-            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
-            audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
-        } else if (urlPath.startsWith("file:///")) {
-            this.audioPath = Path.of(urlPath.substring(8));
+        this.audioPath = AudioManager.pathFromURL(audioPath);
+
+        if (urlPath.startsWith(urlProtocol) || urlPath.startsWith("file:///")) {
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else {
-            // In this case, the file may start with "/".
-            this.audioPath = Path.of(
-                    urlPath.startsWith("/") && !System.getProperty("os.name").startsWith("Mac")
-                    ? urlPath.replaceFirst("/*+", "")
-                    : urlPath
-            );
-            System.err.println(audioPath);
-            System.err.println(this.audioPath);
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -98,7 +98,11 @@ public class StreamedAudio implements Audio {
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         } else {
             // In this case, the file may start with "/".
-            this.audioPath = Path.of(urlPath.startsWith("/") ? urlPath.replaceFirst("/*+", "") : urlPath);
+            this.audioPath = Path.of(
+                    urlPath.startsWith("/") && !System.getProperty("os.name").startsWith("mac")
+                    ? urlPath.replaceFirst("/*+", "")
+                    : urlPath
+            );
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(this.audioPath));
         }
 

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -85,7 +85,18 @@ public class StreamedAudio implements Audio {
      * @param audioPath The path of the audio to use.
      */
     StreamedAudio(URL audioPath) {
-        this.audioPath = Path.of(audioPath.getPath().substring(8));
+        String urlPath = audioPath.getPath();
+        String urlProtocol = audioPath.getProtocol();
+
+        if (urlPath.startsWith(urlProtocol)) {
+            this.audioPath = Path.of(urlPath.substring(urlProtocol.length()));
+        } else if (urlPath.startsWith("file:///")) {
+            this.audioPath = Path.of(urlPath.substring(8));
+        } else {
+            // In this case, the file starts with "/".
+            this.audioPath = Path.of(urlPath.replaceFirst("(/?)*", ""));
+        }
+
         this.id = UUID.randomUUID().toString();
 
         audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));

--- a/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
@@ -6,6 +6,8 @@ import tech.fastj.systems.audio.StreamedAudio;
 
 import javax.sound.sampled.UnsupportedAudioFileException;
 import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.UUID;
 
@@ -16,11 +18,13 @@ import unittest.EnvironmentHelper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AudioManagerTests {
 
     private static final Path TestAudioPath = Path.of("src/test/resources/test_audio.wav");
+    private static final URL TestAudioURL = MemoryAudioTests.class.getClassLoader().getResource("test_audio.wav");
 
     @BeforeAll
     public static void onlyRunIfAudioOutputIsSupported() {
@@ -28,13 +32,13 @@ class AudioManagerTests {
     }
 
     @Test
-    void checkMemoryAudioLoading_withWAVFormatAudio() {
+    void checkMemoryAudioLoading_withPath_withWAVFormatAudio() {
         MemoryAudio memoryAudio = AudioManager.loadMemoryAudio(TestAudioPath);
         assertNotNull(AudioManager.getMemoryAudio(memoryAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio manager.");
     }
 
     @Test
-    void checkMemoryAudioLoading_withWAVFormatAudio_andMultiplePaths() {
+    void checkMemoryAudioLoading_withPaths_withWAVFormatAudio_andMultiplePaths() {
         MemoryAudio[] memoryAudios = AudioManager.loadMemoryAudio(TestAudioPath, TestAudioPath, TestAudioPath);
 
         for (MemoryAudio memoryAudio : memoryAudios) {
@@ -43,7 +47,22 @@ class AudioManagerTests {
     }
 
     @Test
-    void tryMemoryAudioLoading_withIncorrectFilePath() {
+    void checkMemoryAudioLoading_withURL_withWAVFormatAudio() {
+        MemoryAudio memoryAudio = AudioManager.loadMemoryAudio(TestAudioURL);
+        assertNotNull(AudioManager.getMemoryAudio(memoryAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio manager.");
+    }
+
+    @Test
+    void checkMemoryAudioLoading_withURLs_withWAVFormatAudio_andMultiplePaths() {
+        MemoryAudio[] memoryAudios = AudioManager.loadMemoryAudio(TestAudioURL, TestAudioURL, TestAudioURL);
+
+        for (MemoryAudio memoryAudio : memoryAudios) {
+            assertNotNull(AudioManager.getMemoryAudio(memoryAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio manager.");
+        }
+    }
+
+    @Test
+    void tryMemoryAudioLoading_withInvalidFilePath() {
         Path testAudioPath = Path.of(UUID.randomUUID().toString());
         Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadMemoryAudio(testAudioPath));
         Throwable underlyingException = exception.getCause();
@@ -51,7 +70,15 @@ class AudioManagerTests {
     }
 
     @Test
-    void tryMemoryAudioLoading_withUnsupportedAudioFormat() {
+    void tryMemoryAudioLoading_withInvalidFileURL() throws MalformedURLException {
+        URL testAudioPath = new URL("file:///" + UUID.randomUUID());
+        Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadMemoryAudio(testAudioPath));
+        Throwable underlyingException = exception.getCause();
+        assertEquals(FileNotFoundException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
+    }
+
+    @Test
+    void tryMemoryAudioLoading_withPath_withUnsupportedAudioFormat() {
         Path testAudioPath = Path.of("src/test/resources/test_audio.flac");
 
         Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadMemoryAudio(testAudioPath));
@@ -61,13 +88,23 @@ class AudioManagerTests {
     }
 
     @Test
-    void checkStreamedAudioLoading_withWAVFormatAudio() {
+    void tryMemoryAudioLoading_withURL_withUnsupportedAudioFormat() {
+        URL testAudioURL = AudioManagerTests.class.getClassLoader().getResource("test_audio.flac");
+
+        Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadMemoryAudio(testAudioURL));
+        Throwable underlyingException = exception.getCause();
+        assertEquals(UnsupportedAudioFileException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
+        assertTrue(underlyingException.getMessage().endsWith("test_audio.flac is of an unsupported file format \"flac\"."), "Upon reading an unsupported audio file format, an error should be thrown.");
+    }
+
+    @Test
+    void checkStreamedAudioLoading_withPath_withWAVFormatAudio() {
         StreamedAudio streamedAudio = AudioManager.loadStreamedAudio(TestAudioPath);
         assertNotNull(AudioManager.getStreamedAudio(streamedAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio player.");
     }
 
     @Test
-    void checkStreamedAudioLoading_withWAVFormatAudio_andMultiplePaths() {
+    void checkStreamedAudioLoading_withPaths_withWAVFormatAudio_andMultiplePaths() {
         StreamedAudio[] memoryAudios = AudioManager.loadStreamedAudio(TestAudioPath, TestAudioPath, TestAudioPath);
 
         for (StreamedAudio memoryAudio : memoryAudios) {
@@ -76,7 +113,22 @@ class AudioManagerTests {
     }
 
     @Test
-    void tryStreamedAudioLoading_withIncorrectFilePath() {
+    void checkStreamedAudioLoading_withURL_withWAVFormatAudio() {
+        StreamedAudio streamedAudio = AudioManager.loadStreamedAudio(TestAudioURL);
+        assertNotNull(AudioManager.getStreamedAudio(streamedAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio player.");
+    }
+
+    @Test
+    void checkStreamedAudioLoading_withURLs_withWAVFormatAudio_andMultiplePaths() {
+        StreamedAudio[] memoryAudios = AudioManager.loadStreamedAudio(TestAudioURL, TestAudioURL, TestAudioURL);
+
+        for (StreamedAudio memoryAudio : memoryAudios) {
+            assertNotNull(AudioManager.getStreamedAudio(memoryAudio.getID()), "Loading the audio file into memory should cause it to be stored in the audio manager.");
+        }
+    }
+
+    @Test
+    void tryStreamedAudioLoading_withPath_withIncorrectFilePath() {
         Path invalid_testAudioPath = Path.of(UUID.randomUUID().toString());
         Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadStreamedAudio(invalid_testAudioPath));
         Throwable underlyingException = exception.getCause();
@@ -84,12 +136,30 @@ class AudioManagerTests {
     }
 
     @Test
-    void tryStreamedAudioLoading_withUnsupportedAudioFormat() {
+    void tryStreamedAudioLoading_withURL_withIncorrectFilePath() throws MalformedURLException {
+        URL invalid_testAudioURL = new URL("file:///" + UUID.randomUUID());
+        Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadStreamedAudio(invalid_testAudioURL));
+        Throwable underlyingException = exception.getCause();
+        assertEquals(FileNotFoundException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
+    }
+
+    @Test
+    void tryStreamedAudioLoading_withPath_withUnsupportedAudioFormat() {
         Path testAudioPath = Path.of("src/test/resources/test_audio.flac");
 
         Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadStreamedAudio(testAudioPath));
         Throwable underlyingException = exception.getCause();
         assertEquals(UnsupportedAudioFileException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
         assertEquals(underlyingException.getMessage(), testAudioPath.toAbsolutePath() + " is of an unsupported file format \"flac\".", "Upon reading an unsupported audio file format, an error should be thrown.");
+    }
+
+    @Test
+    void tryStreamedAudioLoading_withURL_withUnsupportedAudioFormat() {
+        URL testAudioURL = AudioManagerTests.class.getClassLoader().getResource("test_audio.flac");
+
+        Throwable exception = assertThrows(IllegalStateException.class, () -> AudioManager.loadStreamedAudio(testAudioURL));
+        Throwable underlyingException = exception.getCause();
+        assertEquals(UnsupportedAudioFileException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
+        assertTrue(underlyingException.getMessage().endsWith("test_audio.flac is of an unsupported file format \"flac\"."), "Upon reading an unsupported audio file format, an error should be thrown.");
     }
 }

--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -6,6 +6,7 @@ import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.MemoryAudio;
 import tech.fastj.systems.audio.state.PlaybackState;
 
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class MemoryAudioTests {
 
     private static final Path TestAudioPath = Path.of("src/test/resources/test_audio.wav");
+    private static final URL TestAudioURL = MemoryAudioTests.class.getClassLoader().getResource("test_audio.wav");
 
     @BeforeAll
     public static void onlyRunIfAudioOutputIsSupported() {
@@ -32,10 +34,26 @@ class MemoryAudioTests {
     }
 
     @Test
-    void checkLoadMemoryAudioInstance_shouldMatchExpectedValues() {
+    void checkLoadMemoryAudioInstance_withPath_shouldMatchExpectedValues() {
         MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioPath);
 
         assertEquals(TestAudioPath, audio.getAudioPath(), "After loading the audio into memory, the gotten audio should have the same path object as the one used to load it in.");
+        assertEquals(PlaybackState.Stopped, audio.getCurrentPlaybackState(), "After loading the audio into memory, the gotten audio should be in the \"stopped\" playback state.");
+        assertEquals(PlaybackState.Stopped, audio.getPreviousPlaybackState(), "After loading the audio into memory, the gotten audio's previous playback state should also be \"stopped\".");
+        assertEquals(0L, audio.getPlaybackPosition(), "After loading the audio into memory, the gotten audio should be at the very beginning with playback position.");
+        assertNull(audio.getAudioEventListener().getAudioOpenAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio open\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioStartAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio start\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioPauseAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio pause\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioResumeAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio resume\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioStopAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio stop\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioCloseAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio close\" event action.");
+    }
+
+    @Test
+    void checkLoadMemoryAudioInstance_withURL_shouldMatchExpectedValues() {
+        MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioURL);
+
+        assertTrue(audio.getAudioPath().endsWith("test_audio.wav"), "After loading the audio into memory, the gotten audio should end with the same path to the audio object as the one used to load it in.");
         assertEquals(PlaybackState.Stopped, audio.getCurrentPlaybackState(), "After loading the audio into memory, the gotten audio should be in the \"stopped\" playback state.");
         assertEquals(PlaybackState.Stopped, audio.getPreviousPlaybackState(), "After loading the audio into memory, the gotten audio's previous playback state should also be \"stopped\".");
         assertEquals(0L, audio.getPlaybackPosition(), "After loading the audio into memory, the gotten audio should be at the very beginning with playback position.");

--- a/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
@@ -4,7 +4,9 @@ import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.StreamedAudio;
 import tech.fastj.systems.audio.state.PlaybackState;
 
+import java.net.URL;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class StreamedAudioTests {
 
     private static final Path TestAudioPath = Path.of("src/test/resources/test_audio.wav");
+    private static final URL TestAudioURL = Objects.requireNonNull(MemoryAudioTests.class.getClassLoader().getResource("test_audio.wav"));
 
     @BeforeAll
     public static void onlyRunIfAudioOutputIsSupported() {
@@ -28,10 +31,26 @@ class StreamedAudioTests {
     }
 
     @Test
-    void checkLoadStreamedAudioInstance_shouldMatchExpectedValues() {
+    void checkLoadStreamedAudioInstance_withPath_shouldMatchExpectedValues() {
         StreamedAudio audio = AudioManager.loadStreamedAudio(TestAudioPath);
 
         assertEquals(TestAudioPath, audio.getAudioPath(), "After loading the audio into memory, the gotten audio should have the same path object as the one used to load it in.");
+        assertEquals(PlaybackState.Stopped, audio.getCurrentPlaybackState(), "After loading the audio into memory, the gotten audio should be in the \"stopped\" playback state.");
+        assertEquals(PlaybackState.Stopped, audio.getPreviousPlaybackState(), "After loading the audio into memory, the gotten audio's previous playback state should also be \"stopped\".");
+        assertEquals(0L, audio.getPlaybackPosition(), "After loading the audio into memory, the gotten audio should be at the very beginning with playback position.");
+        assertNull(audio.getAudioEventListener().getAudioOpenAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio open\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioStartAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio start\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioPauseAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio pause\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioResumeAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio resume\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioStopAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio stop\" event action.");
+        assertNull(audio.getAudioEventListener().getAudioCloseAction(), "After loading the audio into memory, the gotten audio's event listener should not contain an \"audio close\" event action.");
+    }
+
+    @Test
+    void checkLoadStreamedAudioInstance_withURL_shouldMatchExpectedValues() {
+        StreamedAudio audio = AudioManager.loadStreamedAudio(TestAudioURL);
+
+        assertTrue(audio.getAudioPath().endsWith("test_audio.wav"), "After loading the audio into memory, the gotten audio should end with the same path to the audio object as the one used to load it in.");
         assertEquals(PlaybackState.Stopped, audio.getCurrentPlaybackState(), "After loading the audio into memory, the gotten audio should be in the \"stopped\" playback state.");
         assertEquals(PlaybackState.Stopped, audio.getPreviousPlaybackState(), "After loading the audio into memory, the gotten audio's previous playback state should also be \"stopped\".");
         assertEquals(0L, audio.getPlaybackPosition(), "After loading the audio into memory, the gotten audio should be at the very beginning with playback position.");


### PR DESCRIPTION
# Add support for loading files via URL
Resolves #77

## Additions
- Added overloads to `loadMemoryAudio`, `loadStreamedAudio`, and `newAudioStream` which take in a `URL` instead of a `Path` object
- Added constructor overloads in `MemoryAudio` and `StreamedAudio` to which take in a `URL` instead of a `Path`
- Added unit tests to ensure `URL` works as expected

