### PR TITLE
Add URL method overload to AudioManager.playSound

### DIFF
--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -56,6 +56,17 @@ public class AudioManager {
     }
 
     /**
+     * Plays the sound file at the specified {@link URL}.
+     *
+     * @param audioPath The {@code URL} path of the sound file to be played.
+     */
+    public static void playSound(URL audioPath) {
+        StreamedAudio audio = new StreamedAudio(audioPath);
+        audio.getAudioEventListener().setAudioStopAction(audioEvent -> audio.stop());
+        audio.play();
+    }
+
+    /**
      * Loads a {@link MemoryAudio} object at the specified path into memory.
      *
      * @param audioPath The path of the {@code MemoryAudio} object to load.

--- a/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import unittest.EnvironmentHelper;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -161,5 +162,15 @@ class AudioManagerTests {
         Throwable underlyingException = exception.getCause();
         assertEquals(UnsupportedAudioFileException.class, underlyingException.getClass(), "The underlying exception's class should match the expected exception's class.");
         assertTrue(underlyingException.getMessage().endsWith("test_audio.flac is of an unsupported file format \"flac\"."), "Upon reading an unsupported audio file format, an error should be thrown.");
+    }
+
+    @Test
+    void checkPlaySound_withPath() {
+        assertDoesNotThrow(() -> AudioManager.playSound(TestAudioPath));
+    }
+
+    @Test
+    void checkPlaySound_withURL() {
+        assertDoesNotThrow(() -> AudioManager.playSound(TestAudioURL));
     }
 }


### PR DESCRIPTION
# Add URL method overload to AudioManager.playSound
Resolves #91

## Additions
- Added a URL method overload to `AudioManager.playSound`
- Added unit testing to both `AudioManager.playSound` methods
