### PR TITLE
More Audio unit tests

### DIFF
--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -125,6 +125,17 @@ class MemoryAudioTests {
     }
 
     @Test
+    void checkSetLoopCount_toContinuousLoop() {
+        MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioPath);
+
+        int expectedLoopCount = MemoryAudio.ContinuousLoop;
+        audio.setLoopCount(expectedLoopCount);
+
+        assertEquals(expectedLoopCount, audio.getLoopCount(), "The audio loop count should be set.");
+        assertTrue(audio.shouldLoop(), "Setting the loop to \"Audio.ContinuousLoop\" should cause the audio to need to loop.");
+    }
+
+    @Test
     void trySetLoopCount_toInvalidValue() {
         MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioPath);
 
@@ -133,6 +144,20 @@ class MemoryAudioTests {
         Throwable exception = assertThrows(IllegalArgumentException.class, () -> audio.setLoopCount(invalidLoopCount));
         String expectedExceptionMessage = "The loop count should not be less than -1.";
         assertEquals(expectedExceptionMessage, exception.getMessage(), "The expected error message should match the actual error message.");
+    }
+
+    @Test
+    void checkSetShouldLoopToFalse_whenLoopCountSaysToLoopContinuously() {
+        MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioPath);
+
+        int expectedLoopCount = MemoryAudio.ContinuousLoop;
+        boolean expectedShouldLoop = false;
+
+        audio.setLoopCount(expectedLoopCount);
+        audio.setShouldLoop(expectedShouldLoop);
+
+        assertEquals(expectedLoopCount, audio.getLoopCount(), "The audio loop count should be set.");
+        assertEquals(expectedShouldLoop, audio.shouldLoop(), "Setting the loop to \"Audio.ContinuousLoop\" then changing the \"shouldLoop\" variable to false should cause the audio to not need to loop.");
     }
 
     @Test
@@ -210,6 +235,16 @@ class MemoryAudioTests {
         assertTrue(audioStopEventBoolean.get(), "After stopping the audio, the \"audio stop\" event action should have been triggered.");
         assertEquals(PlaybackState.Stopped, audio.getCurrentPlaybackState(), "After stopping the audio, the gotten audio should be in the \"stopped\" playback state.");
         assertEquals(PlaybackState.Playing, audio.getPreviousPlaybackState(), "After stopping the audio, the gotten audio's previous playback state should be \"playing\" because its last state was not paused.");
+    }
+
+    @Test
+    void checkStopLoopingNow_whilePlayingAudio() throws InterruptedException {
+        MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioURL);
+        audio.play();
+        TimeUnit.MILLISECONDS.sleep(20);
+        audio.stopLoopingNow();
+
+        assertEquals(MemoryAudio.StopLooping, audio.getLoopCount(), "After being told to stop looping, the audio file's loop count should match the \"stop looping value\".");
     }
 
     @Test

--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -220,4 +220,23 @@ class MemoryAudioTests {
         AudioManager.unloadMemoryAudio(audio.getID());
         assertNull(AudioManager.getMemoryAudio(audio.getID()), "After unloading the audio, it should not be present in the audio manager.");
     }
+
+    @Test
+    void checkGetAudioAfterUnloading_withMultipleAudioFiles() {
+        MemoryAudio[] memoryAudios = new MemoryAudio[4];
+        memoryAudios[0] = AudioManager.loadMemoryAudio(TestAudioPath);
+        memoryAudios[1] = AudioManager.loadMemoryAudio(TestAudioURL);
+        memoryAudios[2] = AudioManager.loadMemoryAudio(TestAudioPath);
+        memoryAudios[3] = AudioManager.loadMemoryAudio(TestAudioURL);
+
+        for (MemoryAudio memoryAudio : memoryAudios) {
+            assertNotNull(AudioManager.getMemoryAudio(memoryAudio.getID()), "The audio should have been loaded into the audio manager successfully.");
+        }
+
+        AudioManager.unloadMemoryAudio(memoryAudios[0].getID(), memoryAudios[1].getID(), memoryAudios[2].getID(), memoryAudios[3].getID());
+
+        for (MemoryAudio memoryAudio : memoryAudios) {
+            assertNull(AudioManager.getMemoryAudio(memoryAudio.getID()), "After unloading the audio, it should not be present in the audio manager.");
+        }
+    }
 }

--- a/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class StreamedAudioTests {
 
     private static final Path TestAudioPath = Path.of("src/test/resources/test_audio.wav");
-    private static final URL TestAudioURL = Objects.requireNonNull(MemoryAudioTests.class.getClassLoader().getResource("test_audio.wav"));
+    private static final URL TestAudioURL = Objects.requireNonNull(StreamedAudioTests.class.getClassLoader().getResource("test_audio.wav"));
 
     @BeforeAll
     public static void onlyRunIfAudioOutputIsSupported() {
@@ -145,5 +145,24 @@ class StreamedAudioTests {
 
         AudioManager.unloadStreamedAudio(audio.getID());
         assertNull(AudioManager.getStreamedAudio(audio.getID()), "After unloading the audio, it should not be present in the audio manager.");
+    }
+
+    @Test
+    void checkGetAudioAfterUnloading_withMultipleAudioFiles() {
+        StreamedAudio[] streamedAudios = new StreamedAudio[4];
+        streamedAudios[0] = AudioManager.loadStreamedAudio(TestAudioPath);
+        streamedAudios[1] = AudioManager.loadStreamedAudio(TestAudioURL);
+        streamedAudios[2] = AudioManager.loadStreamedAudio(TestAudioPath);
+        streamedAudios[3] = AudioManager.loadStreamedAudio(TestAudioURL);
+
+        for (StreamedAudio streamedAudio : streamedAudios) {
+            assertNotNull(AudioManager.getStreamedAudio(streamedAudio.getID()), "The audio should have been loaded into the audio manager successfully.");
+        }
+
+        AudioManager.unloadStreamedAudio(streamedAudios[0].getID(), streamedAudios[1].getID(), streamedAudios[2].getID(), streamedAudios[3].getID());
+
+        for (StreamedAudio streamedAudio : streamedAudios) {
+            assertNull(AudioManager.getStreamedAudio(streamedAudio.getID()), "After unloading the audio, it should not be present in the audio manager.");
+        }
     }
 }


### PR DESCRIPTION
# Add more Audio unit tests

## Additions
- Add unit tests for:
    - unloading `MemoryAudio/StreamedAudio` with multiple audio IDs
    - `MemoryAudio#setShouldLoop`
    - testing the use of `MemoryAudio#ContinuousLoop`
    - `MemoryAudio#stopLoopingNow`


## Other Changes
- Corrected class used for ClassLoader in `StreamedAudioTests`

