### PR TITLE
Add explicit methods to manage behaviors/keys down in LogicManager

### DIFF
--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -469,6 +469,7 @@ public class FastJEngine {
         ThreadFixer.start();
         display.init();
         gameManager.init(display);
+        gameManager.initBehaviors();
 
         timer.init();
         fpsLogger.scheduleWithFixedDelay(() -> {
@@ -492,6 +493,7 @@ public class FastJEngine {
 
             while (accumulator >= updateInterval) {
                 gameManager.update(display);
+                gameManager.updateBehaviors();
 
                 if (!AfterUpdateList.isEmpty()) {
                     for (Runnable action : AfterUpdateList) {
@@ -504,6 +506,7 @@ public class FastJEngine {
             }
 
             gameManager.processInputEvents();
+            gameManager.processKeysDown();
             gameManager.render(display);
             if (!AfterRenderList.isEmpty()) {
                 for (Runnable action : AfterRenderList) {

--- a/src/main/java/tech/fastj/systems/control/LogicManager.java
+++ b/src/main/java/tech/fastj/systems/control/LogicManager.java
@@ -3,15 +3,15 @@ package tech.fastj.systems.control;
 import tech.fastj.engine.FastJEngine;
 import tech.fastj.graphics.display.Display;
 
-import java.awt.event.InputEvent;
-
 import tech.fastj.input.InputManager;
 import tech.fastj.input.keyboard.Keyboard;
 import tech.fastj.input.mouse.Mouse;
 
+import java.awt.event.InputEvent;
+
 /**
  * The basis of game management in any game made with FastJ.
- *
+ * <p>
  * This class defines the basic events and actions that all logic managers need to address:
  * <ul>
  *     <li>Game Initialization</li>
@@ -37,6 +37,9 @@ public interface LogicManager {
      */
     void init(Display display);
 
+    /** Initializes the logic manager's behaviors (called after {@link #init(Display)}). */
+    void initBehaviors();
+
     /**
      * Allows the logic manager to process all pending input events.
      *
@@ -45,6 +48,9 @@ public interface LogicManager {
      * @see InputManager
      */
     void processInputEvents();
+
+    /** Allows the logic manager to process keys that are currently pressed. */
+    void processKeysDown();
 
     /**
      * Allows the logic manager to take in an input event.
@@ -66,6 +72,9 @@ public interface LogicManager {
      *                display while updating the game state.
      */
     void update(Display display);
+
+    /** Updates the logic manager's behaviors (called after {@link #update(Display)}). */
+    void updateBehaviors();
 
     /**
      * Allows the logic manager to render irs game's current state to the screen.

--- a/src/main/java/tech/fastj/systems/control/SimpleManager.java
+++ b/src/main/java/tech/fastj/systems/control/SimpleManager.java
@@ -34,6 +34,33 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
         BehaviorManager.addListenerList(this);
     }
 
+    @Override
+    public void initBehaviors() {
+        this.initBehaviorListeners();
+    }
+
+    /** Processes all stored input events. */
+    @Override
+    public void processInputEvents() {
+        inputManager.processEvents();
+    }
+
+    @Override
+    public void processKeysDown() {
+        inputManager.fireKeysDown();
+    }
+
+    /** Stores the specified input event to be processed later ({@link #processInputEvents()}). */
+    @Override
+    public void receivedInputEvent(InputEvent inputEvent) {
+        inputManager.receivedInputEvent(inputEvent);
+    }
+
+    @Override
+    public void updateBehaviors() {
+        this.updateBehaviorListeners();
+    }
+
     /**
      * Renders the contents of the manager's {@code DrawableManager} to the {@code Display}.
      *
@@ -46,18 +73,6 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
                 drawableManager.getUIElements(),
                 camera
         );
-    }
-
-    /** Processes all stored input events. */
-    @Override
-    public void processInputEvents() {
-        inputManager.processEvents();
-    }
-
-    /** Stores the specified input event to be processed later ({@link #processInputEvents()}). */
-    @Override
-    public void receivedInputEvent(InputEvent inputEvent) {
-        inputManager.receivedInputEvent(inputEvent);
     }
 
     /**

--- a/src/test/java/unittest/testcases/engine/FastJEngineTests.java
+++ b/src/test/java/unittest/testcases/engine/FastJEngineTests.java
@@ -27,12 +27,14 @@ class FastJEngineTests {
         FastJEngine.init("yeet", new SimpleManager() {
             @Override
             public void init(Display display) {
-                FastJEngine.runAfterUpdate(() -> ranAfterUpdate.set(true));
+                FastJEngine.runAfterUpdate(() -> {
+                    ranAfterUpdate.set(true);
+                    FastJEngine.forceCloseGame();
+                });
             }
 
             @Override
             public void update(Display display) {
-                FastJEngine.forceCloseGame();
             }
 
             @Override
@@ -50,7 +52,10 @@ class FastJEngineTests {
         FastJEngine.init("yeet", new SimpleManager() {
             @Override
             public void init(Display display) {
-                FastJEngine.runAfterRender(() -> ranAfterRender.set(true));
+                FastJEngine.runAfterRender(() -> {
+                    ranAfterRender.set(true);
+                    FastJEngine.forceCloseGame();
+                });
             }
 
             @Override
@@ -59,7 +64,6 @@ class FastJEngineTests {
 
             @Override
             public void render(Display display) {
-                FastJEngine.forceCloseGame();
             }
         });
         FastJEngine.run();


### PR DESCRIPTION
# Add Explicit Methods to Manage Behaviors/Keys Pressed in LogicManager
Fixes #96

## Additions
- Added explicit methods to manage behaviors/keys pressed in `LogicManager`
    - `initBehaviors` -- requests that the `LogicManager` initialize its behaviors
    - `updateBehaviors` -- requests that the `LogicManager` update its behaviors
    - `processKeysDown` -- requests that the `LogicManager` process keys pressed down


## Bug Fixes
- (#96) Fixed issue where `LogicManager` did not initialize, update, or destroy behaviors
- Fixed issue where `LogicManager` did not act on keys down


## Breaking Changes
- `SceneManager` no longer handles input at the `update()` stage. All input dealt with in `SceneManager` will be called before `render()`.
- `SceneManager` behavior initialization now occurs after background adjustments and scene initialization. 


## Other Changes
- Replaced (update/init/render)CurrentScene methods with safe(Update/Init/Render) methods, respectively.

