### PR TITLE
Add method calls to destroy behaviors in Scene/SimpleManager

### DIFF
--- a/src/main/java/tech/fastj/systems/behaviors/BehaviorHandler.java
+++ b/src/main/java/tech/fastj/systems/behaviors/BehaviorHandler.java
@@ -52,6 +52,11 @@ public interface BehaviorHandler {
         BehaviorManager.updateBehaviorListeners(this);
     }
 
+    /** Destroys all behaviors in the behavior handler, without removing them. */
+    default void destroyBehaviorListeners() {
+        BehaviorManager.destroyListenerList(this);
+    }
+
     /** Removes all behavior listeners in the behavior handler. */
     default void clearBehaviorListeners() {
         BehaviorManager.clearListenerList(this);

--- a/src/main/java/tech/fastj/systems/behaviors/BehaviorManager.java
+++ b/src/main/java/tech/fastj/systems/behaviors/BehaviorManager.java
@@ -76,6 +76,17 @@ public class BehaviorManager {
     }
 
     /**
+     * Destroys all behaviors from the list aliased to the specified {@link BehaviorHandler}, without removing them.
+     *
+     * @param behaviorHandler The {@code BehaviorHandler} used as the alias to destroy all behavior listeners.
+     */
+    public static void destroyListenerList(BehaviorHandler behaviorHandler) {
+        for (GameObject listener : BehaviorListenerLists.get(behaviorHandler).values()) {
+            listener.destroyAllBehaviors();
+        }
+    }
+
+    /**
      * Removes all elements from the list aliased to the specified {@link BehaviorHandler}.
      *
      * @param behaviorHandler The {@code BehaviorHandler} used as the alias to remove all behavior listeners.

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -122,6 +122,7 @@ public abstract class Scene implements BehaviorHandler, TagHandler {
     /** Resets the scene's state entirely. */
     public void reset() {
         this.setInitialized(false);
+        this.destroyBehaviorListeners();
         this.clearAllLists();
         camera.reset();
     }

--- a/src/main/java/tech/fastj/systems/control/SimpleManager.java
+++ b/src/main/java/tech/fastj/systems/control/SimpleManager.java
@@ -87,6 +87,7 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
     @Override
     public void reset() {
         camera.reset();
+        this.destroyBehaviorListeners();
         inputManager.clearAllLists();
         drawableManager.clearAllLists();
         this.clearTaggableEntities();


### PR DESCRIPTION
# Add Method Calls to Destroy Behaviors in Scene/SimpleManager
Fixes #99

## Additions
- `BehaviorManager.destroyListenerList` for destroying the behaviors of any `BehaviorHandler`'s behavior listener list.
- `BehaviorHandler.destroyBehaviorListeners` for calling the `BehaviorManager`'s behavior destroying method.


## Bug Fixes
- (#99) Added behavior destroy calls to both `SimpleManager` and `Scene` classes' `reset` methods.
