### PR TITLE
Clear AfterUpdateList/AfterRenderList in engine exit method

### DIFF
--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -559,6 +559,8 @@ public class FastJEngine {
         StreamedAudioPlayer.reset();
         BehaviorManager.reset();
         TagManager.reset();
+        AfterUpdateList.clear();
+        AfterRenderList.clear();
 
         // engine speed variables
         targetFPS = 0;


### PR DESCRIPTION
# Clear AfterUpdateList/AfterRenderList in Engine Exit Method
Fixes #97

## Additions
- Clear AfterUpdateList/AfterRenderList in `FastJEngine.exit()`

