### PR TITLE
Reorganize unit tests to match main packages

### DIFF
--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -5,8 +5,10 @@ module fastj.library.test {
     opens unittest.testcases.engine to org.junit.platform.commons;
 
     opens unittest.testcases.graphics to org.junit.platform.commons;
+    opens unittest.testcases.graphics.display to org.junit.platform.commons;
     opens unittest.testcases.graphics.game to org.junit.platform.commons;
     opens unittest.testcases.graphics.gradients to org.junit.platform.commons;
+    opens unittest.testcases.graphics.io to org.junit.platform.commons;
     opens unittest.testcases.graphics.util to org.junit.platform.commons;
 
     opens unittest.testcases.input.keyboard to org.junit.platform.commons;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -6,12 +6,13 @@ module fastj.library.test {
 
     opens unittest.testcases.graphics to org.junit.platform.commons;
     opens unittest.testcases.graphics.game to org.junit.platform.commons;
+    opens unittest.testcases.graphics.gradients to org.junit.platform.commons;
     opens unittest.testcases.graphics.util to org.junit.platform.commons;
-    opens unittest.testcases.graphics.util.gradients to org.junit.platform.commons;
+
+    opens unittest.testcases.input.keyboard to org.junit.platform.commons;
 
     opens unittest.testcases.math to org.junit.platform.commons;
 
     opens unittest.testcases.systems.audio to org.junit.platform.commons;
     opens unittest.testcases.systems.control to org.junit.platform.commons;
-    opens unittest.testcases.systems.input.keyboard to org.junit.platform.commons;
 }

--- a/src/test/java/unittest/testcases/graphics/display/CameraTests.java
+++ b/src/test/java/unittest/testcases/graphics/display/CameraTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.graphics;
+package unittest.testcases.graphics.display;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;

--- a/src/test/java/unittest/testcases/graphics/gradients/GradientsTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/GradientsTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.graphics.util.gradients;
+package unittest.testcases.graphics.gradients;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;

--- a/src/test/java/unittest/testcases/graphics/gradients/LinearGradientTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/LinearGradientTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.graphics.util.gradients;
+package unittest.testcases.graphics.gradients;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;

--- a/src/test/java/unittest/testcases/graphics/gradients/RadialGradientTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/RadialGradientTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.graphics.util.gradients;
+package unittest.testcases.graphics.gradients;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;

--- a/src/test/java/unittest/testcases/graphics/io/PsdfUtilTests.java
+++ b/src/test/java/unittest/testcases/graphics/io/PsdfUtilTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.graphics.util;
+package unittest.testcases.graphics.io;
 
 import tech.fastj.math.Pointf;
 import tech.fastj.graphics.Boundary;

--- a/src/test/java/unittest/testcases/input/keyboard/KeysTests.java
+++ b/src/test/java/unittest/testcases/input/keyboard/KeysTests.java
@@ -1,4 +1,4 @@
-package unittest.testcases.systems.input.keyboard;
+package unittest.testcases.input.keyboard;
 
 import org.junit.jupiter.api.Test;
 import tech.fastj.input.keyboard.Keys;


### PR DESCRIPTION
# Reorganize Unit Tests to Match `main` package Structure

- Reorganized `src/test/java/unittest/testcases` to match the general directory structure of `src/main/java/tech/fastj`
