### PR TITLE
fixed package definitions, updated main module description

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,20 +1,29 @@
+import tech.fastj.resources.ResourceManager;
+
 /**
  * The FastJ Library in its entirety.
  * <p>
- * FastJ does not use any external dependencies -- it relies entirely on Java 11's {@code java.desktop} module, using
- * java2d to display output.
+ * FastJ relies on Java 11's <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/module-summary.html"
+ * target="_blank">java.desktop</a> module, using java2d to display output. Logging capabilities are provided by
+ * <a href="https://www.slf4j.org/" target="_blank">SLF4J</a>.
  * <p>
- * This game library is split into 5 parts:
+ * This game library is split into several parts:
  * <ol>
  *     <li>{@link tech.fastj.engine} -- The package containing the base of the game engine.</li>
  *     <li>{@link tech.fastj.graphics} -- Game objects and other graphical content.</li>
- *     <li>{@link tech.fastj.input} -- User input via keyboard/mouse.</li>
+ *     <li>{@link tech.fastj.input} -- User input and events via keyboard &amp; mouse.</li>
+ *     <li>{@link tech.fastj.logging} -- FastJ's logging system, abstracted over
+ *          <a href="https://www.slf4j.org/" target="_blank">SLF4J</a>.</li>
  *     <li>{@link tech.fastj.math} -- FastJ's supplementary mathematics and vector library.</li>
+ *     <li>{@link tech.fastj.resources} -- FastJ's {@link ResourceManager resource manager}, model loading system, image
+ *          system, and other file-related content.</li>
  *     <li>{@link tech.fastj.systems} -- Audio, behaviors, and other miscellaneous features of FastJ.</li>
  * </ol>
  * <p>
- * For more information, check out
- * <a href="https://github.com/fastjengine/FastJ" target="_blank">the github repository.</a>
+ * For more information on the source code, check out
+ * <a href="https://github.com/fastjengine/FastJ" target="_blank">the github repository</a>.
+ * <p>
+ * For more information on FastJ itself, check out <a href="https://fastj.tech" target="_blank">FastJ's website</a>.
  */
 module fastj.library {
     requires transitive java.desktop;

--- a/src/main/java/tech/fastj/engine/internals/package-info.java
+++ b/src/main/java/tech/fastj/engine/internals/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's internal engine classes. */
 package tech.fastj.engine.internals;
-
-/**
- * FastJ's internal engine classes.
- */

--- a/src/main/java/tech/fastj/engine/package-info.java
+++ b/src/main/java/tech/fastj/engine/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's internal engine classes. */
 package tech.fastj.engine;
-
-/**
- * FastJ's internal engine classes.
- */

--- a/src/main/java/tech/fastj/graphics/game/package-info.java
+++ b/src/main/java/tech/fastj/graphics/game/package-info.java
@@ -1,5 +1,2 @@
+/** {@code GameObject}, {@code Model2D}, and other specific instances. */
 package tech.fastj.graphics.game;
-
-/**
- * {@code GameObject}, {@code Model2D}, and other specific instances.
- */

--- a/src/main/java/tech/fastj/graphics/io/package-info.java
+++ b/src/main/java/tech/fastj/graphics/io/package-info.java
@@ -1,5 +1,0 @@
-package tech.fastj.graphics.io;
-
-/**
- * FastJ model file IO.
- */

--- a/src/main/java/tech/fastj/graphics/package-info.java
+++ b/src/main/java/tech/fastj/graphics/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's Graphics and Rendering system. */
 package tech.fastj.graphics;
-
-/**
- * FastJ's Graphics and Rendering system.
- */

--- a/src/main/java/tech/fastj/graphics/ui/elements/package-info.java
+++ b/src/main/java/tech/fastj/graphics/ui/elements/package-info.java
@@ -1,5 +1,2 @@
+/** The different UI elements available in FastJ. */
 package tech.fastj.graphics.ui.elements;
-
-/**
- * The different UI elements available in FastJ.
- */

--- a/src/main/java/tech/fastj/graphics/ui/package-info.java
+++ b/src/main/java/tech/fastj/graphics/ui/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's UI system. */
 package tech.fastj.graphics.ui;
-
-/**
- * FastJ's UI system.
- */

--- a/src/main/java/tech/fastj/graphics/util/package-info.java
+++ b/src/main/java/tech/fastj/graphics/util/package-info.java
@@ -1,5 +1,2 @@
+/** Graphics utilities. */
 package tech.fastj.graphics.util;
-
-/**
- * Graphics utilities.
- */

--- a/src/main/java/tech/fastj/input/keyboard/package-info.java
+++ b/src/main/java/tech/fastj/input/keyboard/package-info.java
@@ -1,5 +1,2 @@
+/** Handles all keyboard inputs. */
 package tech.fastj.input.keyboard;
-
-/**
- * Handles all keyboard inputs.
- */

--- a/src/main/java/tech/fastj/input/mouse/package-info.java
+++ b/src/main/java/tech/fastj/input/mouse/package-info.java
@@ -1,5 +1,2 @@
+/** Handles all mouse input. */
 package tech.fastj.input.mouse;
-
-/**
- * Handles all mouse input.
- */

--- a/src/main/java/tech/fastj/input/package-info.java
+++ b/src/main/java/tech/fastj/input/package-info.java
@@ -1,5 +1,2 @@
+/** Handles all input events. */
 package tech.fastj.input;
-
-/**
- * Handles all input events.
- */

--- a/src/main/java/tech/fastj/math/package-info.java
+++ b/src/main/java/tech/fastj/math/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's math library. */
 package tech.fastj.math;
-
-/**
- * FastJ's math library.
- */

--- a/src/main/java/tech/fastj/resources/files/package-info.java
+++ b/src/main/java/tech/fastj/resources/files/package-info.java
@@ -1,0 +1,2 @@
+/** System providing simple methods to work with files. */
+package tech.fastj.resources.files;

--- a/src/main/java/tech/fastj/systems/audio/package-info.java
+++ b/src/main/java/tech/fastj/systems/audio/package-info.java
@@ -1,5 +1,2 @@
+/** FastJ's audio system. */
 package tech.fastj.systems.audio;
-
-/**
- * FastJ's audio system.
- */

--- a/src/main/java/tech/fastj/systems/audio/state/package-info.java
+++ b/src/main/java/tech/fastj/systems/audio/state/package-info.java
@@ -1,5 +1,2 @@
+/** Data about what state the audio is currently in. */
 package tech.fastj.systems.audio.state;
-
-/**
- * Data about what state the audio is currently in.
- */

--- a/src/main/java/tech/fastj/systems/behaviors/package-info.java
+++ b/src/main/java/tech/fastj/systems/behaviors/package-info.java
@@ -1,5 +1,2 @@
+/** API for FastJ's behaviour system. */
 package tech.fastj.systems.behaviors;
-
-/**
- * API for FastJ's behaviour system.
- */

--- a/src/main/java/tech/fastj/systems/fio/package-info.java
+++ b/src/main/java/tech/fastj/systems/fio/package-info.java
@@ -1,5 +1,0 @@
-package tech.fastj.systems.fio;
-
-/**
- * System providing simple methods to work with files.
- */

--- a/src/main/java/tech/fastj/systems/package-info.java
+++ b/src/main/java/tech/fastj/systems/package-info.java
@@ -1,5 +1,2 @@
+/** Different systems inside FastJ to aid in making games with the engine. */
 package tech.fastj.systems;
-
-/**
- * Different systems inside FastJ to aid in making games with the engine.
- */


### PR DESCRIPTION
# Fixed Package Definitions, Updated Main Module Description

## Changes
- moved `systems/fio/package-info.java` to `resources/files`
- deleted `graphics/io/package-info.java` for its lack of use in the current setup
- moved javadoc for each `package-info` to the proper place
- formatted javadoc to one-line docs
- updated main module description to match current state of FastJ
