### PR TITLE
Add dependabot to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # Dependencies managed in repository root build.gradle
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# Add Dependabot

[Dependabot](https://github.com/dependabot) automates dependency updates, which can be especially useful now that we have an incoming dependency in the form of SLF4J.
