### PR TITLE
add/subtract/multiply/divide overloads, origin vectors, unit vectors, and direction vector functions

### DIFF
--- a/src/main/java/tech/fastj/graphics/util/DrawUtil.java
+++ b/src/main/java/tech/fastj/graphics/util/DrawUtil.java
@@ -433,7 +433,7 @@ public final class DrawUtil {
      * @return A 4 {@code Pointf} array based on the location and size specified.
      */
     public static Pointf[] createBoxFromImage(BufferedImage source) {
-        return createBoxFromImage(source, new Pointf());
+        return createBoxFromImage(source, Pointf.origin());
     }
 
     /**
@@ -471,7 +471,7 @@ public final class DrawUtil {
      * @return The center of the array.
      */
     public static Pointf centerOf(Pointf[] points) {
-        Pointf result = new Pointf();
+        Pointf result = Pointf.origin();
         for (Pointf p : points) {
             result.add(p);
         }

--- a/src/main/java/tech/fastj/input/mouse/Mouse.java
+++ b/src/main/java/tech/fastj/input/mouse/Mouse.java
@@ -48,7 +48,7 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
     private static int lastScrollDirection = Mouse.InitialScrollDirection;
 
     private static boolean currentlyOnScreen;
-    private static Pointf mouseLocation = new Pointf();
+    private static Pointf mouseLocation = Pointf.origin();
 
     private static final Map<Integer, Consumer<MouseEvent>> MouseEventProcessor = Map.of(
             MouseEvent.MOUSE_PRESSED, mouseEvent -> {

--- a/src/main/java/tech/fastj/math/Point.java
+++ b/src/main/java/tech/fastj/math/Point.java
@@ -159,6 +159,19 @@ public class Point {
     }
 
     /**
+     * Static method to add a {@code Point} object by two integer values, and return a new {@code Point}.
+     *
+     * @param p  The {@code Point} used for addition.
+     * @param i1 The {@code integer} used for addition on the {@code x} value.
+     * @param i2 The {@code integer} used for addition on the {@code y} value.
+     * @return Returns a new {@code Point} with coordinates equal to the added values from the {@code Point} and the
+     * integer values.
+     */
+    public static Point add(Point p, int i1, int i2) {
+        return new Point(p.x + i1, p.y + i2);
+    }
+
+    /**
      * Static method to subtract two Points (from the parameters specified) together, and return a new {@code Point}
      * object.
      *
@@ -182,6 +195,19 @@ public class Point {
      */
     public static Point subtract(Point p, int i) {
         return new Point(p.x - i, p.y - i);
+    }
+
+    /**
+     * Static method to subtract a {@code Point} object by two integer values, and return a new {@code Point}.
+     *
+     * @param p  The {@code Point} used for subtraction; the {@code Point} acting as the first value in subtraction.
+     * @param i1 Integer value used for subtraction; the second value used in subtraction for the {@code x} value.
+     * @param i2 Integer value used for subtraction; the second value used in subtraction for the {@code y} value.
+     * @return Returns a new {@code Point} with coordinates equal to the subtracted values from the {@code Point} and
+     * the integer values.
+     */
+    public static Point subtract(Point p, int i1, int i2) {
+        return new Point(p.x - i1, p.y - i2);
     }
 
     /**
@@ -209,6 +235,19 @@ public class Point {
     }
 
     /**
+     * Static method to multiply a {@code Point} object by two integer values, and return a new {@code Point}.
+     *
+     * @param p  The {@code Point} used for multiplication.
+     * @param i1 Integer value used for multiplication on the {@code x} value.
+     * @param i2 Integer value used for multiplication on the {@code y} value.
+     * @return Returns a new {@code Point} with coordinates equal to the multiplied values from the {@code Point} and
+     * the integer values.
+     */
+    public static Point multiply(Point p, int i1, int i2) {
+        return new Point(p.x * i1, p.y * i2);
+    }
+
+    /**
      * Static method to divide two {@code Point} objects (from the parameters specified) together, and return a new
      * {@code Point}.
      *
@@ -230,6 +269,19 @@ public class Point {
      */
     public static Point divide(Point p, int i) {
         return new Point(p.x / i, p.y / i);
+    }
+
+    /**
+     * Static method to divide a {@code Point} object by a integer value, and return a new {@code Point}.
+     *
+     * @param p  The {@code Point} used for division; the {@code Point} acting as the first value in division.
+     * @param i1 Integer value used for division; the second value used in division for the {@code x} value.
+     * @param i2 Integer value used for division; the second value used in division for the {@code y} value.
+     * @return Returns a new {@code Point} with coordinates equal to the divided values from the {@code Point} and the
+     * integer value.
+     */
+    public static Point divide(Point p, int i1, int i2) {
+        return new Point(p.x / i1, p.y / i2);
     }
 
     /**
@@ -475,6 +527,21 @@ public class Point {
     }
 
     /**
+     * Adds the values of this {@code Point} to the specified integer values, and returns a new {@code Point} with the
+     * modified values.
+     *
+     * @param i1 {@code x} value to add this {@code Point} to.
+     * @param i2 {@code y} value to add this {@code Point} to.
+     * @return Returns this {@code Point}, with the modified values.
+     */
+    public Point add(int i1, int i2) {
+        x += i1;
+        y += i2;
+
+        return this;
+    }
+
+    /**
      * Subtracts the values of this {@code Point} by the specified {@code Point}, and returns a new {@code Point} with
      * the modified values.
      *
@@ -498,6 +565,21 @@ public class Point {
     public Point subtract(int f) {
         x -= f;
         y -= f;
+
+        return this;
+    }
+
+    /**
+     * Subtracts the values of this {@code Point} by the specified integer values, and returns a new {@code Point} with
+     * the modified values.
+     *
+     * @param i1 {@code x} value to subtract this {@code Point} by.
+     * @param i2 {@code y} value to subtract this {@code Point} by.
+     * @return Returns this {@code Point}, with the modified values.
+     */
+    public Point subtract(int i1, int i2) {
+        x -= i1;
+        y -= i2;
 
         return this;
     }
@@ -531,6 +613,21 @@ public class Point {
     }
 
     /**
+     * Multiplies the values of this {@code Point} by the specified integer values, and returns a new {@code Point} with
+     * the modified values.
+     *
+     * @param i1 {@code x} value to multiply this {@code Point} by.
+     * @param i2 {@code y} value to multiply this {@code Point} by.
+     * @return Returns this {@code Point}, with the modified values.
+     */
+    public Point multiply(int i1, int i2) {
+        x *= i1;
+        y *= i2;
+
+        return this;
+    }
+
+    /**
      * Divides the values of this {@code Point} by the specified {@code Point}, and returns a new {@code Point} with the
      * modified values.
      *
@@ -554,6 +651,21 @@ public class Point {
     public Point divide(int f) {
         x /= f;
         y /= f;
+
+        return this;
+    }
+
+    /**
+     * Divides the values of this {@code Point} by the specified integer values, and returns a new {@code Point} with the
+     * modified values.
+     *
+     * @param i1 {@code x} value to divide this {@code Point} by.
+     * @param i2 {@code y} value to divide this {@code Point} by.
+     * @return Returns this {@code Point}, with the modified values.
+     */
+    public Point divide(int i1, int i2) {
+        x /= i1;
+        y /= i2;
 
         return this;
     }

--- a/src/main/java/tech/fastj/math/Point.java
+++ b/src/main/java/tech/fastj/math/Point.java
@@ -656,8 +656,8 @@ public class Point {
     }
 
     /**
-     * Divides the values of this {@code Point} by the specified integer values, and returns a new {@code Point} with the
-     * modified values.
+     * Divides the values of this {@code Point} by the specified integer values, and returns a new {@code Point} with
+     * the modified values.
      *
      * @param i1 {@code x} value to divide this {@code Point} by.
      * @param i2 {@code y} value to divide this {@code Point} by.
@@ -768,7 +768,7 @@ public class Point {
         int magnitude = (int) Math.sqrt((double) (x * x) + (double) (y * y));
 
         if (magnitude == 0) {
-            return Point.Origin.copy();
+            return Point.origin();
         }
 
         int normalizedX = x / magnitude;
@@ -788,7 +788,7 @@ public class Point {
         float magnitude = (float) Math.sqrt(((float) x * (float) x) + ((float) y * (float) y));
 
         if (magnitude == 0f) {
-            return Pointf.Origin.copy();
+            return Pointf.origin();
         }
 
         float normalizedX = x / magnitude;

--- a/src/main/java/tech/fastj/math/Point.java
+++ b/src/main/java/tech/fastj/math/Point.java
@@ -81,6 +81,60 @@ public class Point {
     }
 
     /**
+     * {@code Point} representing a 2D graph's origin as a pair of {@code integer}s: {@code (0, 0)}.
+     *
+     * @return The {@code origin} instance.
+     */
+    public static Point origin() {
+        return new Point();
+    }
+
+    /**
+     * {@code Point} representing a unit vector in a 2D graph as a pair of {@code integer}s: {@code (0, 0)}.
+     *
+     * @return The {@code unit} vector instance.
+     */
+    public static Point unit() {
+        return new Point(1);
+    }
+
+    /**
+     * {@code Point} representing an up vector in a 2D graph as a pair of {@code integer}s: {@code (0, -1)}.
+     *
+     * @return The {@code up} vector instance.
+     */
+    public static Point up() {
+        return new Point(0, -1);
+    }
+
+    /**
+     * {@code Point} representing a down vector in a 2D graph as a pair of {@code integer}s: {@code (0, 1)}.
+     *
+     * @return The {@code down} vector instance.
+     */
+    public static Point down() {
+        return new Point(0, 1);
+    }
+
+    /**
+     * {@code Point} representing a left vector in a 2D graph as a pair of {@code integer}s: {@code (-1, 0)}.
+     *
+     * @return The {@code left} vector instance.
+     */
+    public static Point left() {
+        return new Point(-1, 0);
+    }
+
+    /**
+     * {@code Point} representing a right vector in a 2D graph as a pair of {@code integer}s: {@code (1, 0)}.
+     *
+     * @return The {@code right} vector instance.
+     */
+    public static Point right() {
+        return new Point(1, 0);
+    }
+
+    /**
      * Static method to add two {@code Point}s (from the parameters specified) together, and return a new {@code Point}
      * object.
      *

--- a/src/main/java/tech/fastj/math/Pointf.java
+++ b/src/main/java/tech/fastj/math/Pointf.java
@@ -68,6 +68,60 @@ public class Pointf {
     }
 
     /**
+     * {@code Pointf} representing a 2D graph's origin as a pair of {@code float}s: {@code (0f, 0f)}.
+     *
+     * @return The {@code origin} instance.
+     */
+    public static Pointf origin() {
+        return new Pointf();
+    }
+
+    /**
+     * {@code Pointf} representing a unit vector in a 2D graph as a pair of {@code float}s: {@code (0f, 0f)}.
+     *
+     * @return The {@code unit} vector instance.
+     */
+    public static Pointf unit() {
+        return new Pointf(1f);
+    }
+
+    /**
+     * {@code Pointf} representing an up vector in a 2D graph as a pair of {@code float}s: {@code (0f, -1f)}.
+     *
+     * @return The {@code up} vector instance.
+     */
+    public static Pointf up() {
+        return new Pointf(0f, -1f);
+    }
+
+    /**
+     * {@code Pointf} representing a down vector in a 2D graph as a pair of {@code float}s: {@code (0f, 1f)}.
+     *
+     * @return The {@code down} vector instance.
+     */
+    public static Pointf down() {
+        return new Pointf(0f, 1f);
+    }
+
+    /**
+     * {@code Pointf} representing a left vector in a 2D graph as a pair of {@code float}s: {@code (-1f, 0f)}.
+     *
+     * @return The {@code left} vector instance.
+     */
+    public static Pointf left() {
+        return new Pointf(-1f, 0f);
+    }
+
+    /**
+     * {@code Pointf} representing a right vector in a 2D graph as a pair of {@code float}s: {@code (1f, 0f)}.
+     *
+     * @return The {@code right} vector instance.
+     */
+    public static Pointf right() {
+        return new Pointf(1f, 0f);
+    }
+
+    /**
      * Static method to add two {@code Pointf}s (from the parameters specified) together, and return a new {@code
      * Pointf} object.
      *

--- a/src/main/java/tech/fastj/math/Pointf.java
+++ b/src/main/java/tech/fastj/math/Pointf.java
@@ -671,8 +671,8 @@ public class Pointf {
     }
 
     /**
-     * Divides the values of this {@code Pointf} by the specified float values, and returns a new {@code Pointf} with the
-     * modified values.
+     * Divides the values of this {@code Pointf} by the specified float values, and returns a new {@code Pointf} with
+     * the modified values.
      *
      * @param f1 {@code x} value to divide this {@code Pointf} by.
      * @param f2 {@code y} value to divide this {@code Pointf} by.
@@ -764,7 +764,7 @@ public class Pointf {
         float magnitude = (float) Math.sqrt((x * x) + (y * y));
 
         if (magnitude == 0f) {
-            return Pointf.Origin.copy();
+            return Pointf.origin();
         }
 
         float normalizedX = x / magnitude;

--- a/src/main/java/tech/fastj/math/Pointf.java
+++ b/src/main/java/tech/fastj/math/Pointf.java
@@ -146,6 +146,19 @@ public class Pointf {
     }
 
     /**
+     * Static method to add a {@code Pointf} object by two float values, and return a new {@code Pointf}.
+     *
+     * @param p  The {@code Pointf} used for addition.
+     * @param f1 The {@code float} used for addition on the {@code x} value.
+     * @param f2 The {@code float} used for addition on the {@code y} value.
+     * @return Returns a new {@code Pointf} with coordinates equal to the added values from the {@code Pointf} and the
+     * float values.
+     */
+    public static Pointf add(Pointf p, float f1, float f2) {
+        return new Pointf(p.x + f1, p.y + f2);
+    }
+
+    /**
      * Static method to subtract two Points (from the parameters specified) together, and return a new {@code Pointf}
      * object.
      *
@@ -170,6 +183,19 @@ public class Pointf {
      */
     public static Pointf subtract(Pointf p, float f) {
         return new Pointf(p.x - f, p.y - f);
+    }
+
+    /**
+     * Static method to subtract a {@code Pointf} object by two float values, and return a new {@code Pointf}.
+     *
+     * @param p  The {@code Pointf} used for subtraction; the {@code Pointf} acting as the first value in subtraction.
+     * @param f1 float value used for subtraction; the second value used in subtraction for the {@code x} value.
+     * @param f2 float value used for subtraction; the second value used in subtraction for the {@code y} value.
+     * @return Returns a new {@code Pointf} with coordinates equal to the subtracted values from the {@code Pointf} and
+     * the float values.
+     */
+    public static Pointf subtract(Pointf p, float f1, float f2) {
+        return new Pointf(p.x - f1, p.y - f2);
     }
 
     /**
@@ -198,6 +224,19 @@ public class Pointf {
     }
 
     /**
+     * Static method to multiply a {@code Pointf} object by two float values, and return a new {@code Pointf}.
+     *
+     * @param p  The {@code Pointf} used for multiplication.
+     * @param f1 float value used for multiplication on the {@code x} value.
+     * @param f2 float value used for multiplication on the {@code y} value.
+     * @return Returns a new {@code Pointf} with coordinates equal to the multiplied values from the {@code Pointf} and
+     * the float values.
+     */
+    public static Pointf multiply(Pointf p, float f1, float f2) {
+        return new Pointf(p.x * f1, p.y * f2);
+    }
+
+    /**
      * Static method to divide two {@code Pointf} objects (from the parameters specified) together, and return a new
      * {@code Pointf}.
      *
@@ -220,6 +259,19 @@ public class Pointf {
      */
     public static Pointf divide(Pointf p, float f) {
         return new Pointf(p.x / f, p.y / f);
+    }
+
+    /**
+     * Static method to divide a {@code Pointf} object by a float value, and return a new {@code Pointf}.
+     *
+     * @param p  The {@code Pointf} used for division; the {@code Pointf} acting as the first value in division.
+     * @param f1 float value used for division; the second value used in division for the {@code x} value.
+     * @param f2 float value used for division; the second value used in division for the {@code y} value.
+     * @return Returns a new {@code Pointf} with coordinates equal to the divided values from the {@code Pointf} and the
+     * float value.
+     */
+    public static Pointf divide(Pointf p, float f1, float f2) {
+        return new Pointf(p.x / f1, p.y / f2);
     }
 
     /**
@@ -490,6 +542,21 @@ public class Pointf {
     }
 
     /**
+     * Adds the values of this {@code Pointf} to the specified float values, and returns a new {@code Pointf} with the
+     * modified values.
+     *
+     * @param f1 {@code x} value to add this {@code Pointf} to.
+     * @param f2 {@code y} value to add this {@code Pointf} to.
+     * @return Returns this {@code Pointf}, with the modified values.
+     */
+    public Pointf add(float f1, float f2) {
+        x += f1;
+        y += f2;
+
+        return this;
+    }
+
+    /**
      * Subtracts the values of this {@code Pointf} by the specified {@code Pointf}, and returns a new {@code Pointf}
      * with the modified values.
      *
@@ -513,6 +580,21 @@ public class Pointf {
     public Pointf subtract(float f) {
         x -= f;
         y -= f;
+
+        return this;
+    }
+
+    /**
+     * Subtracts the values of this {@code Pointf} by the specified float values, and returns a new {@code Pointf} with
+     * the modified values.
+     *
+     * @param f1 {@code x} value to subtract this {@code Pointf} by.
+     * @param f2 {@code y} value to subtract this {@code Pointf} by.
+     * @return Returns this {@code Pointf}, with the modified values.
+     */
+    public Pointf subtract(float f1, float f2) {
+        x -= f1;
+        y -= f2;
 
         return this;
     }
@@ -546,6 +628,21 @@ public class Pointf {
     }
 
     /**
+     * Multiplies the values of this {@code Pointf} by the specified float values, and returns a new {@code Pointf} with
+     * the modified values.
+     *
+     * @param f1 {@code x} value to multiply this {@code Pointf} by.
+     * @param f2 {@code y} value to multiply this {@code Pointf} by.
+     * @return Returns this {@code Pointf}, with the modified values.
+     */
+    public Pointf multiply(float f1, float f2) {
+        x *= f1;
+        y *= f2;
+
+        return this;
+    }
+
+    /**
      * Divides the values of this {@code Pointf} by the specified {@code Pointf}, and returns a new {@code Pointf} with
      * the modified values.
      *
@@ -569,6 +666,21 @@ public class Pointf {
     public Pointf divide(float f) {
         x /= f;
         y /= f;
+
+        return this;
+    }
+
+    /**
+     * Divides the values of this {@code Pointf} by the specified float values, and returns a new {@code Pointf} with the
+     * modified values.
+     *
+     * @param f1 {@code x} value to divide this {@code Pointf} by.
+     * @param f2 {@code y} value to divide this {@code Pointf} by.
+     * @return Returns this {@code Pointf}, with the modified values.
+     */
+    public Pointf divide(float f1, float f2) {
+        x /= f1;
+        y /= f2;
 
         return this;
     }

--- a/src/main/java/tech/fastj/math/Transform2D.java
+++ b/src/main/java/tech/fastj/math/Transform2D.java
@@ -12,17 +12,17 @@ import java.util.Objects;
 public class Transform2D {
 
     /** {@link Pointf} representing a default translation of {@code (0f, 0f)}. */
-    public static final Pointf DefaultTranslation = Pointf.Origin.copy();
+    public static final Pointf DefaultTranslation = Pointf.origin();
     /** {@link Pointf} representing a default scale of {@code (1f, 1f)}. */
-    public static final Pointf DefaultScale = new Pointf(1f).copy();
+    public static final Pointf DefaultScale = Pointf.unit();
     /** {@code float} representing a default rotation value of {@code 0f}. */
     public static final float DefaultRotation = 0f;
 
     private final AffineTransform translationTransform = new AffineTransform();
     private final AffineTransform rotationTransform = new AffineTransform();
     private final AffineTransform scaleTransform = new AffineTransform();
-    private Pointf lastRotationPoint = Pointf.Origin.copy();
-    private Pointf lastScalePoint = Pointf.Origin.copy();
+    private Pointf lastRotationPoint = Pointf.origin();
+    private Pointf lastScalePoint = Pointf.origin();
     private float rotation = DefaultRotation;
 
     public AffineTransform getAffineTransform() {

--- a/src/test/java/unittest/mock/systems/behaviors/MockBehavior.java
+++ b/src/test/java/unittest/mock/systems/behaviors/MockBehavior.java
@@ -12,7 +12,7 @@ public class MockBehavior implements Behavior {
 
     @Override
     public void init(GameObject gameObject) {
-        pointf = new Pointf();
+        pointf = Pointf.origin();
     }
 
     @Override

--- a/src/test/java/unittest/testcases/graphics/DrawableTests.java
+++ b/src/test/java/unittest/testcases/graphics/DrawableTests.java
@@ -42,7 +42,7 @@ class DrawableTests {
         Polygon2D polygon2D = Polygon2D.fromPoints(square);
 
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
                 Polygon2D.fromPoints(square2)
@@ -76,7 +76,7 @@ class DrawableTests {
             Text2D text2D = Text2D.fromText(text);
 
             Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-            Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+            Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
             Polygon2D[] polygons = {
                     Polygon2D.fromPoints(square1),
                     Polygon2D.fromPoints(square2)

--- a/src/test/java/unittest/testcases/graphics/game/Model2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Model2DTests.java
@@ -19,7 +19,7 @@ class Model2DTests {
     @Test
     void checkModel2DCreation_withPolygon2DArrayParam() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
 
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
@@ -38,7 +38,7 @@ class Model2DTests {
     @Test
     void checkModel2DCreation_withPolygon2DArrayParam_andRandomlyGeneratedShowParam() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
 
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
@@ -59,7 +59,7 @@ class Model2DTests {
     @Test
     void checkModel2DCreation_withPolygon2DArrayParam_andRandomlyGeneratedShowParam_andRandomlyGeneratedTransformParams() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
 
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
@@ -87,7 +87,7 @@ class Model2DTests {
     @Test
     void checkModel2DCreation_withPolygon2DArrayParam_andRandomlyGeneratedShowParam_andRandomlyGeneratedTransformParams_usingMethodChaining() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
 
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
@@ -117,7 +117,7 @@ class Model2DTests {
     @Test
     void checkModel2DBoundsCreation_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
 
         Polygon2D[] polygons = {
                 Polygon2D.fromPoints(square1),
@@ -139,7 +139,7 @@ class Model2DTests {
     @Test
     void checkModel2DTranslation_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf randomTranslation = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
 
         Polygon2D[] expectedPolygons = {
@@ -166,7 +166,7 @@ class Model2DTests {
     @Test
     void checkModel2DRotation_aroundOrigin_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         float randomRotation = Maths.random(-5000f, 5000f);
 
         Polygon2D[] expectedPolygons = {
@@ -193,7 +193,7 @@ class Model2DTests {
     @Test
     void checkModel2DRotation_aroundModelCenter_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf expectedModelCenter = Pointf.subtract(square2[2], square1[0]).divide(2f).add(square1[0]);
         float randomRotation = Maths.random(-5000f, 5000f);
 
@@ -221,7 +221,7 @@ class Model2DTests {
     @Test
     void checkModel2DRotation_aroundRandomCenter_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf randomCenter = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
         float randomRotation = Maths.random(-5000f, 5000f);
 
@@ -249,7 +249,7 @@ class Model2DTests {
     @Test
     void checkModel2DScaling_aroundOrigin_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf randomScaling = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
 
         Polygon2D[] expectedPolygons = {
@@ -276,7 +276,7 @@ class Model2DTests {
     @Test
     void checkModel2DScaling_aroundModelCenter_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf randomScaling = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
         Pointf expectedModelCenter = Pointf.subtract(square2[2], square1[0]).divide(2f).add(square1[0]);
 
@@ -304,7 +304,7 @@ class Model2DTests {
     @Test
     void checkModel2DScaling_aroundRandomCenter_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         Pointf randomScaling = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
         Pointf randomCenter = new Pointf(Maths.random(-50f, 50f), Maths.random(-50f, 50f));
 
@@ -332,7 +332,7 @@ class Model2DTests {
     @Test
     void checkModel2DScaling_usingScaleAsFloat_shouldMatchExpected() {
         Pointf[] square1 = DrawUtil.createBox(Pointf.Origin, 50f);
-        Pointf[] square2 = DrawUtil.createBox(Pointf.add(Pointf.Origin, 25f), 50f);
+        Pointf[] square2 = DrawUtil.createBox(Pointf.origin().add(25f), 50f);
         float randomScaling = Maths.random(-50f, 50f);
         Pointf expectedModelCenter = Pointf.subtract(square2[2], square1[0]).divide(2f).add(square1[0]);
 

--- a/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
@@ -138,7 +138,7 @@ class Polygon2DTests {
                 .withTransform(translationBeforeReset, rotationBeforeReset, scaleBeforeReset)
                 .build();
 
-        Pointf[] newSquarePoints = DrawUtil.createBox(Pointf.Origin.copy().add(1f), 20f);
+        Pointf[] newSquarePoints = DrawUtil.createBox(Pointf.unit(), 20f);
         square.modifyPoints(newSquarePoints, true, true, true);
 
         assertArrayEquals(newSquarePoints, square.getPoints(), "The expected points should match the square's points -- no transformations have been performed.");
@@ -159,7 +159,7 @@ class Polygon2DTests {
                 .withTransform(translationBeforeReset, rotationBeforeReset, scaleBeforeReset)
                 .build();
 
-        Pointf[] newSquarePoints = DrawUtil.createBox(Pointf.Origin.copy().add(1f), 20f);
+        Pointf[] newSquarePoints = DrawUtil.createBox(Pointf.unit(), 20f);
         square.modifyPoints(newSquarePoints, false, false, false);
 
         assertFalse(Arrays.deepEquals(newSquarePoints, square.getPoints()), "The expected points should not match the square's transformed points -- no transformations have been reset.");

--- a/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
+++ b/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
@@ -82,7 +82,7 @@ class DrawUtilTests {
     @Test
     void checkGeneratePath2D_withPointfArray() {
         Pointf[] polygon = {
-                new Pointf(),
+                Pointf.origin(),
                 new Pointf(50f, 30f),
                 new Pointf(-5f, 47f),
                 new Pointf(45f, 20f),

--- a/src/test/java/unittest/testcases/math/PointTests.java
+++ b/src/test/java/unittest/testcases/math/PointTests.java
@@ -20,7 +20,7 @@ class PointTests {
 
     @Test
     void checkPointCreation_withNoConstructorParams() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         assertEquals(0, pt.x, "The x value of the Point should default to 0.");
         assertEquals(0, pt.y, "The y value of the Point should default to 0.");
     }
@@ -68,7 +68,7 @@ class PointTests {
 
     @Test
     void checkPointAddition_withIntegerValue() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         pt.add(5);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
@@ -77,7 +77,7 @@ class PointTests {
 
     @Test
     void checkPointAddition_withIntegerValues() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         pt.add(5, 10);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
@@ -86,7 +86,7 @@ class PointTests {
 
     @Test
     void checkPointAddition_withPointObjects() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         Point pt2 = new Point(5);
         pt.add(pt2);
 
@@ -96,7 +96,7 @@ class PointTests {
 
     @Test
     void checkPointSubtraction_withIntegerValue() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         pt.subtract(5);
 
         assertEquals(-5, pt.x, "The x value of the Point should equal -5.");
@@ -105,7 +105,7 @@ class PointTests {
 
     @Test
     void checkPointSubtraction_withIntegerValues() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         pt.subtract(5, 10);
 
         assertEquals(-5, pt.x, "The x value of the Point should equal -5.");
@@ -114,7 +114,7 @@ class PointTests {
 
     @Test
     void checkPointSubtraction_withPointObjects() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         Point pt2 = new Point(5);
         pt.subtract(pt2);
 
@@ -124,7 +124,7 @@ class PointTests {
 
     @Test
     void checkPointMultiplication_withIntegerValue() {
-        Point pt = new Point(1);
+        Point pt = Point.unit();
         pt.multiply(5);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
@@ -133,7 +133,7 @@ class PointTests {
 
     @Test
     void checkPointMultiplication_withIntegerValues() {
-        Point pt = new Point(1);
+        Point pt = Point.unit();
         pt.multiply(5, 10);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
@@ -142,7 +142,7 @@ class PointTests {
 
     @Test
     void checkPointMultiplication_withPointObjects() {
-        Point pt = new Point(1);
+        Point pt = Point.unit();
         Point pt2 = new Point(5);
         pt.multiply(pt2);
 
@@ -180,7 +180,7 @@ class PointTests {
 
     @Test
     void checkArithmeticChaining_withPointObjectsAndIntegerValues() {
-        Point pt = new Point()
+        Point pt = Point.origin()
                 .add(2)                                // (2, 2)
                 .add(new Point(3))                 // (5, 5)
                 .multiply(new Point(3, 4))  // (15, 20)
@@ -228,12 +228,12 @@ class PointTests {
         Point pt = new Point(13, 37);
         pt.reset();
 
-        assertEquals(new Point(), pt, "The point's x and y values should have been reset to (0, 0).");
+        assertEquals(Point.origin(), pt, "The point's x and y values should have been reset to (0, 0).");
     }
 
     @Test
     void checkPointSetting() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         pt.set(13, 37);
 
         assertEquals(13, pt.x, "The x value of the Point should equal 13.");
@@ -293,7 +293,7 @@ class PointTests {
 
     @Test
     void checkPointNormalization_whenMagnitudeIsZero_usingFloatingPointDivision() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         float expectedNormalizedX = 0f;
         float expectedNormalizedY = 0f;
 
@@ -316,7 +316,7 @@ class PointTests {
 
     @Test
     void checkPointNormalization_whenMagnitudeIsZero_usingIntegerDivision() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         int expectedNormalizedX = 0;
         int expectedNormalizedY = 0;
 
@@ -470,8 +470,8 @@ class PointTests {
 
 
     @Test
-    void static_checkPointAddition_withIntegerValues() {
-        Point pt = new Point();
+    void static_checkPointAddition_withIntegerValue() {
+        Point pt = Point.origin();
         Point added = Point.add(pt, 5);
 
         assertEquals(5, added.x, "The x value of the Point should equal 5.");
@@ -479,8 +479,17 @@ class PointTests {
     }
 
     @Test
+    void static_checkPointAddition_withIntegerValues() {
+        Point pt = Point.origin();
+        Point added = Point.add(pt, 5, 10);
+
+        assertEquals(5, added.x, "The x value of the Point should equal 5.");
+        assertEquals(10, added.y, "The y value of the Point should equal 10.");
+    }
+
+    @Test
     void static_checkPointAddition_withPointObjects() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         Point pt2 = new Point(5);
         Point added = Point.add(pt, pt2);
 
@@ -489,8 +498,8 @@ class PointTests {
     }
 
     @Test
-    void static_checkPointSubtraction_withIntegerValues() {
-        Point pt = new Point();
+    void static_checkPointSubtraction_withIntegerValue() {
+        Point pt = Point.origin();
         Point subtracted = Point.subtract(pt, 5);
 
         assertEquals(-5, subtracted.x, "The x value of the Point should equal -5.");
@@ -498,8 +507,17 @@ class PointTests {
     }
 
     @Test
+    void static_checkPointSubtraction_withIntegerValues() {
+        Point pt = Point.origin();
+        Point subtracted = Point.subtract(pt, 5, 10);
+
+        assertEquals(-5, subtracted.x, "The x value of the Point should equal -5.");
+        assertEquals(-10, subtracted.y, "The y value of the Point should equal -10.");
+    }
+
+    @Test
     void static_checkPointSubtraction_withPointObjects() {
-        Point pt = new Point();
+        Point pt = Point.origin();
         Point pt2 = new Point(5);
         Point subtracted = Point.subtract(pt, pt2);
 
@@ -508,8 +526,8 @@ class PointTests {
     }
 
     @Test
-    void static_checkPointMultiplication_withIntegerValues() {
-        Point pt = new Point(1);
+    void static_checkPointMultiplication_withIntegerValue() {
+        Point pt = Point.unit();
         Point multiplied = Point.multiply(pt, 5);
 
         assertEquals(5, multiplied.x, "The x value of the Point should equal 5.");
@@ -517,8 +535,17 @@ class PointTests {
     }
 
     @Test
+    void static_checkPointMultiplication_withIntegerValues() {
+        Point pt = Point.unit();
+        Point multiplied = Point.multiply(pt, 5, 10);
+
+        assertEquals(5, multiplied.x, "The x value of the Point should equal 5.");
+        assertEquals(10, multiplied.y, "The y value of the Point should equal 10.");
+    }
+
+    @Test
     void static_checkPointMultiplication_withPointObjects() {
-        Point pt = new Point(1);
+        Point pt = Point.unit();
         Point pt2 = new Point(5);
         Point multiplied = Point.multiply(pt, pt2);
 
@@ -527,12 +554,21 @@ class PointTests {
     }
 
     @Test
-    void static_checkPointDivision_withIntegerValues() {
+    void static_checkPointDivision_withIntegerValue() {
         Point pt = new Point(25);
         Point divided = Point.divide(pt, 5);
 
         assertEquals(5, divided.x, "The x value of the Point should equal 5.");
         assertEquals(5, divided.y, "The y value of the Point should equal 5.");
+    }
+
+    @Test
+    void static_checkPointDivision_withIntegerValues() {
+        Point pt = new Point(25);
+        Point divided = Point.divide(pt, 5, 25);
+
+        assertEquals(5, divided.x, "The x value of the Point should equal 5.");
+        assertEquals(1, divided.y, "The y value of the Point should equal 1.");
     }
 
     @Test

--- a/src/test/java/unittest/testcases/math/PointTests.java
+++ b/src/test/java/unittest/testcases/math/PointTests.java
@@ -67,12 +67,21 @@ class PointTests {
     }
 
     @Test
-    void checkPointAddition_withIntegerValues() {
+    void checkPointAddition_withIntegerValue() {
         Point pt = new Point();
         pt.add(5);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
         assertEquals(5, pt.y, "The y value of the Point should equal 5.");
+    }
+
+    @Test
+    void checkPointAddition_withIntegerValues() {
+        Point pt = new Point();
+        pt.add(5, 10);
+
+        assertEquals(5, pt.x, "The x value of the Point should equal 5.");
+        assertEquals(10, pt.y, "The y value of the Point should equal 10.");
     }
 
     @Test
@@ -86,12 +95,21 @@ class PointTests {
     }
 
     @Test
-    void checkPointSubtraction_withIntegerValues() {
+    void checkPointSubtraction_withIntegerValue() {
         Point pt = new Point();
         pt.subtract(5);
 
         assertEquals(-5, pt.x, "The x value of the Point should equal -5.");
         assertEquals(-5, pt.y, "The y value of the Point should equal -5.");
+    }
+
+    @Test
+    void checkPointSubtraction_withIntegerValues() {
+        Point pt = new Point();
+        pt.subtract(5, 10);
+
+        assertEquals(-5, pt.x, "The x value of the Point should equal -5.");
+        assertEquals(-10, pt.y, "The y value of the Point should equal -10.");
     }
 
     @Test
@@ -105,12 +123,21 @@ class PointTests {
     }
 
     @Test
-    void checkPointMultiplication_withIntegerValues() {
+    void checkPointMultiplication_withIntegerValue() {
         Point pt = new Point(1);
         pt.multiply(5);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
         assertEquals(5, pt.y, "The y value of the Point should equal 5.");
+    }
+
+    @Test
+    void checkPointMultiplication_withIntegerValues() {
+        Point pt = new Point(1);
+        pt.multiply(5, 10);
+
+        assertEquals(5, pt.x, "The x value of the Point should equal 5.");
+        assertEquals(10, pt.y, "The y value of the Point should equal 10.");
     }
 
     @Test
@@ -124,12 +151,21 @@ class PointTests {
     }
 
     @Test
-    void checkPointDivision_withIntegerValues() {
+    void checkPointDivision_withIntegerValue() {
         Point pt = new Point(25);
         pt.divide(5);
 
         assertEquals(5, pt.x, "The x value of the Point should equal 5.");
         assertEquals(5, pt.y, "The y value of the Point should equal 5.");
+    }
+
+    @Test
+    void checkPointDivision_withIntegerValues() {
+        Point pt = new Point(25);
+        pt.divide(5, 25);
+
+        assertEquals(5, pt.x, "The x value of the Point should equal 5.");
+        assertEquals(1, pt.y, "The y value of the Point should equal 1.");
     }
 
     @Test

--- a/src/test/java/unittest/testcases/math/PointfTests.java
+++ b/src/test/java/unittest/testcases/math/PointfTests.java
@@ -20,7 +20,7 @@ class PointfTests {
 
     @Test
     void checkPointfCreation_withNoConstructorParams() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         assertEquals(0f, ptf.x, "The x value of the Pointf should default to 0f.");
         assertEquals(0f, ptf.y, "The y value of the Pointf should default to 0f.");
     }
@@ -59,7 +59,7 @@ class PointfTests {
 
     @Test
     void checkPointfAddition_withFloatValue() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         ptf.add(5f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
@@ -68,7 +68,7 @@ class PointfTests {
 
     @Test
     void checkPointfAddition_withFloatValues() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         ptf.add(5f, 10f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
@@ -77,7 +77,7 @@ class PointfTests {
 
     @Test
     void checkPointfAddition_withPointfObjects() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf ptf2 = new Pointf(5f);
         ptf.add(ptf2);
 
@@ -87,7 +87,7 @@ class PointfTests {
 
     @Test
     void checkPointfSubtraction_withFloatValue() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         ptf.subtract(5f);
 
         assertEquals(-5f, ptf.x, "The x value of the Pointf should equal -5f.");
@@ -96,7 +96,7 @@ class PointfTests {
 
     @Test
     void checkPointfSubtraction_withFloatValues() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         ptf.subtract(5f, 10f);
 
         assertEquals(-5f, ptf.x, "The x value of the Pointf should equal -5f.");
@@ -105,7 +105,7 @@ class PointfTests {
 
     @Test
     void checkPointfSubtraction_withPointfObjects() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf ptf2 = new Pointf(5f);
         ptf.subtract(ptf2);
 
@@ -115,7 +115,7 @@ class PointfTests {
 
     @Test
     void checkPointfMultiplication_withFloatValue() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         ptf.multiply(5f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
@@ -124,7 +124,7 @@ class PointfTests {
 
     @Test
     void checkPointfMultiplication_withFloatValues() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         ptf.multiply(5f, 10f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
@@ -133,7 +133,7 @@ class PointfTests {
 
     @Test
     void checkPointfMultiplication_withPointfObjects() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         Pointf ptf2 = new Pointf(5f);
         ptf.multiply(ptf2);
 
@@ -171,7 +171,7 @@ class PointfTests {
 
     @Test
     void checkArithmeticChaining_withPointfObjectsAndFloatValues() {
-        Pointf ptf = new Pointf()
+        Pointf ptf = Pointf.origin()
                 .add(2f)                                    // (2f, 2f)
                 .add(new Pointf(3f))                    // (5f, 5f)
                 .multiply(new Pointf(3f, 4f))    // (15f, 20f)
@@ -219,12 +219,12 @@ class PointfTests {
         Pointf ptf = new Pointf(13f, 37f);
         ptf.reset();
 
-        assertEquals(new Pointf(), ptf, "The Pointf's x and y values should have been reset to (0f, 0f).");
+        assertEquals(Pointf.origin(), ptf, "The Pointf's x and y values should have been reset to (0f, 0f).");
     }
 
     @Test
     void checkPointfSetting() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         ptf.set(13f, 37f);
 
         assertEquals(13f, ptf.x, "The x value of the Pointf should equal 13f.");
@@ -270,7 +270,7 @@ class PointfTests {
 
     @Test
     void checkPointNormalization_whenMagnitudeIsZero() {
-        Pointf pt = new Pointf();
+        Pointf pt = Pointf.origin();
         float expectedNormalizedX = 0f;
         float expectedNormalizedY = 0f;
 
@@ -356,7 +356,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfAddition_withFloatValue() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf added = Pointf.add(ptf, 5f);
 
         assertEquals(5f, added.x, "The x value of the Pointf should equal 5f.");
@@ -365,7 +365,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfAddition_withFloatValues() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf added = Pointf.add(ptf, 5f, 10f);
 
         assertEquals(5f, added.x, "The x value of the Pointf should equal 5f.");
@@ -374,7 +374,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfAddition_withPointfObjects() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf ptf2 = new Pointf(5f);
         Pointf added = Pointf.add(ptf, ptf2);
 
@@ -384,7 +384,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfSubtraction_withFloatValue() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf subtracted = Pointf.subtract(ptf, 5f);
 
         assertEquals(-5f, subtracted.x, "The x value of the Pointf should equal -5f.");
@@ -393,7 +393,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfSubtraction_withFloatValues() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf subtracted = Pointf.subtract(ptf, 5f, 10f);
 
         assertEquals(-5f, subtracted.x, "The x value of the Pointf should equal -5f.");
@@ -402,7 +402,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfSubtraction_withPointfObjects() {
-        Pointf ptf = new Pointf();
+        Pointf ptf = Pointf.origin();
         Pointf ptf2 = new Pointf(5f);
         Pointf subtracted = Pointf.subtract(ptf, ptf2);
 
@@ -412,7 +412,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfMultiplication_withFloatValue() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         Pointf multiplied = Pointf.multiply(ptf, 5f);
 
         assertEquals(5f, multiplied.x, "The x value of the Pointf should equal 5f.");
@@ -421,7 +421,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfMultiplication_withFloatValues() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         Pointf multiplied = Pointf.multiply(ptf, 5f, 10f);
 
         assertEquals(5f, multiplied.x, "The x value of the Pointf should equal 5f.");
@@ -430,7 +430,7 @@ class PointfTests {
 
     @Test
     void static_checkPointfMultiplication_withPointfObjects() {
-        Pointf ptf = new Pointf(1f);
+        Pointf ptf = Pointf.unit();
         Pointf ptf2 = new Pointf(5f);
         Pointf multiplied = Pointf.multiply(ptf, ptf2);
 

--- a/src/test/java/unittest/testcases/math/PointfTests.java
+++ b/src/test/java/unittest/testcases/math/PointfTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.math;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Point;
 import tech.fastj.math.Pointf;
@@ -15,6 +11,10 @@ import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PointfTests {
 
@@ -58,12 +58,21 @@ class PointfTests {
     }
 
     @Test
-    void checkPointfAddition_withFloatValues() {
+    void checkPointfAddition_withFloatValue() {
         Pointf ptf = new Pointf();
         ptf.add(5f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, ptf.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void checkPointfAddition_withFloatValues() {
+        Pointf ptf = new Pointf();
+        ptf.add(5f, 10f);
+
+        assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(10f, ptf.y, "The y value of the Pointf should equal 10f.");
     }
 
     @Test
@@ -77,12 +86,21 @@ class PointfTests {
     }
 
     @Test
-    void checkPointfSubtraction_withFloatValues() {
+    void checkPointfSubtraction_withFloatValue() {
         Pointf ptf = new Pointf();
         ptf.subtract(5f);
 
         assertEquals(-5f, ptf.x, "The x value of the Pointf should equal -5f.");
         assertEquals(-5f, ptf.y, "The y value of the Pointf should equal -5f.");
+    }
+
+    @Test
+    void checkPointfSubtraction_withFloatValues() {
+        Pointf ptf = new Pointf();
+        ptf.subtract(5f, 10f);
+
+        assertEquals(-5f, ptf.x, "The x value of the Pointf should equal -5f.");
+        assertEquals(-10f, ptf.y, "The y value of the Pointf should equal -10f.");
     }
 
     @Test
@@ -96,12 +114,21 @@ class PointfTests {
     }
 
     @Test
-    void checkPointfMultiplication_withFloatValues() {
+    void checkPointfMultiplication_withFloatValue() {
         Pointf ptf = new Pointf(1f);
         ptf.multiply(5f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, ptf.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void checkPointfMultiplication_withFloatValues() {
+        Pointf ptf = new Pointf(1f);
+        ptf.multiply(5f, 10f);
+
+        assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(10f, ptf.y, "The y value of the Pointf should equal 10f.");
     }
 
     @Test
@@ -115,12 +142,21 @@ class PointfTests {
     }
 
     @Test
-    void checkPointfDivision_withFloatValues() {
+    void checkPointfDivision_withFloatValue() {
         Pointf ptf = new Pointf(25f);
         ptf.divide(5f);
 
         assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, ptf.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void checkPointfDivision_withFloatValues() {
+        Pointf ptf = new Pointf(25f);
+        ptf.divide(5f, 25f);
+
+        assertEquals(5f, ptf.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(1f, ptf.y, "The y value of the Pointf should equal 1f.");
     }
 
     @Test
@@ -319,12 +355,21 @@ class PointfTests {
 
 
     @Test
-    void static_checkPointfAddition_withFloatValues() {
+    void static_checkPointfAddition_withFloatValue() {
         Pointf ptf = new Pointf();
         Pointf added = Pointf.add(ptf, 5f);
 
         assertEquals(5f, added.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, added.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void static_checkPointfAddition_withFloatValues() {
+        Pointf ptf = new Pointf();
+        Pointf added = Pointf.add(ptf, 5f, 10f);
+
+        assertEquals(5f, added.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(10f, added.y, "The y value of the Pointf should equal 10f.");
     }
 
     @Test
@@ -338,12 +383,21 @@ class PointfTests {
     }
 
     @Test
-    void static_checkPointfSubtraction_withFloatValues() {
+    void static_checkPointfSubtraction_withFloatValue() {
         Pointf ptf = new Pointf();
         Pointf subtracted = Pointf.subtract(ptf, 5f);
 
         assertEquals(-5f, subtracted.x, "The x value of the Pointf should equal -5f.");
         assertEquals(-5f, subtracted.y, "The y value of the Pointf should equal -5f.");
+    }
+
+    @Test
+    void static_checkPointfSubtraction_withFloatValues() {
+        Pointf ptf = new Pointf();
+        Pointf subtracted = Pointf.subtract(ptf, 5f, 10f);
+
+        assertEquals(-5f, subtracted.x, "The x value of the Pointf should equal -5f.");
+        assertEquals(-10f, subtracted.y, "The y value of the Pointf should equal -10f.");
     }
 
     @Test
@@ -357,12 +411,21 @@ class PointfTests {
     }
 
     @Test
-    void static_checkPointfMultiplication_withFloatValues() {
+    void static_checkPointfMultiplication_withFloatValue() {
         Pointf ptf = new Pointf(1f);
         Pointf multiplied = Pointf.multiply(ptf, 5f);
 
         assertEquals(5f, multiplied.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, multiplied.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void static_checkPointfMultiplication_withFloatValues() {
+        Pointf ptf = new Pointf(1f);
+        Pointf multiplied = Pointf.multiply(ptf, 5f, 10f);
+
+        assertEquals(5f, multiplied.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(10f, multiplied.y, "The y value of the Pointf should equal 10f.");
     }
 
     @Test
@@ -376,12 +439,21 @@ class PointfTests {
     }
 
     @Test
-    void static_checkPointfDivision_withFloatValues() {
+    void static_checkPointfDivision_withFloatValue() {
         Pointf ptf = new Pointf(25f);
         Pointf divided = Pointf.divide(ptf, 5f);
 
         assertEquals(5f, divided.x, "The x value of the Pointf should equal 5f.");
         assertEquals(5f, divided.y, "The y value of the Pointf should equal 5f.");
+    }
+
+    @Test
+    void static_checkPointfDivision_withFloatValues() {
+        Pointf ptf = new Pointf(25f);
+        Pointf divided = Pointf.divide(ptf, 5f, 25f);
+
+        assertEquals(5f, divided.x, "The x value of the Pointf should equal 5f.");
+        assertEquals(1f, divided.y, "The y value of the Pointf should equal 1f.");
     }
 
     @Test

--- a/src/test/java/unittest/testcases/math/PointfTests.java
+++ b/src/test/java/unittest/testcases/math/PointfTests.java
@@ -1,5 +1,9 @@
 package unittest.testcases.math;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import tech.fastj.math.Maths;
 import tech.fastj.math.Point;
 import tech.fastj.math.Pointf;
@@ -11,10 +15,6 @@ import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PointfTests {
 


### PR DESCRIPTION
# Multiple QOL Improvements from Point/Pointf


## Additions
- add/subtract/multiply/divide overloads -- two `integer`s/`float`s as an alternative to creating a new `Point/f`
- origin vector function -- `Point/f.origin()` creates a separate instance per function call, which on the user's end is less verbose than `Point/f.Origin.copy()`
- unit vector functions -- `Point/f.unit()` (similarly to the new `Point/f.origin()`, creates separate instances per function call
- direction vector functions -- `up/down/left/right()` have been added to `Point/f` to help reduce the verbosity from having the users create these themselves


## Other Changes
- migrated many variables in the engine's source code to the new functions

