### PR TITLE
remove redundant BasicStroke equals option

### DIFF
--- a/src/main/java/tech/fastj/graphics/util/DrawUtil.java
+++ b/src/main/java/tech/fastj/graphics/util/DrawUtil.java
@@ -2,7 +2,6 @@ package tech.fastj.graphics.util;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
-
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.game.Polygon2D;
 
@@ -252,29 +251,6 @@ public final class DrawUtil {
                 && mGradientPaint1.getCycleMethod().equals(mGradientPaint2.getCycleMethod())
                 && Arrays.deepEquals(mGradientPaint1.getColors(), mGradientPaint2.getColors())
                 && Arrays.equals(mGradientPaint1.getFractions(), mGradientPaint2.getFractions());
-    }
-
-    /**
-     * Checks for equality between two {@link BasicStroke outline stroke} objects.
-     *
-     * @param basicStroke1 The first {@code BasicStroke} specified.
-     * @param basicStroke2 The second {@code BasicStroke} specified.
-     * @return Whether the two {@code BasicStroke}s are equal.
-     */
-    public static boolean outlineStrokeEquals(BasicStroke basicStroke1, BasicStroke basicStroke2) {
-        if (basicStroke1.getDashArray() == null && basicStroke2.getDashArray() != null) {
-            return false;
-        }
-        if (basicStroke1.getDashArray() == null && basicStroke2.getDashArray() != null) {
-            return false;
-        }
-
-        return basicStroke1.getEndCap() == basicStroke2.getEndCap()
-                && basicStroke1.getLineJoin() == basicStroke2.getLineJoin()
-                && Maths.floatEquals(basicStroke1.getLineWidth(), basicStroke2.getLineWidth())
-                && Maths.floatEquals(basicStroke1.getDashPhase(), basicStroke2.getDashPhase())
-                && Maths.floatEquals(basicStroke1.getMiterLimit(), basicStroke2.getMiterLimit())
-                && Arrays.equals(basicStroke1.getDashArray(), basicStroke2.getDashArray());
     }
 
     /**

--- a/src/main/java/tech/fastj/graphics/util/DrawUtil.java
+++ b/src/main/java/tech/fastj/graphics/util/DrawUtil.java
@@ -2,6 +2,7 @@ package tech.fastj.graphics.util;
 
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
+
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.game.Polygon2D;
 

--- a/src/test/java/unittest/testcases/engine/FastJEngineTests.java
+++ b/src/test/java/unittest/testcases/engine/FastJEngineTests.java
@@ -54,7 +54,7 @@ class FastJEngineTests {
             }
         });
 
-        FastJEngine.configureExceptionAction(ExceptionAction.LogError);
+        FastJEngine.configureExceptionAction(ExceptionAction.Nothing);
         FastJEngine.run();
 
         assertTrue(ranAfterUpdate.get(), "After one update completes, the ranAfterUpdate boolean should have been set to true.");
@@ -82,7 +82,7 @@ class FastJEngineTests {
             }
         });
 
-        FastJEngine.configureExceptionAction(ExceptionAction.LogError);
+        FastJEngine.configureExceptionAction(ExceptionAction.Nothing);
         FastJEngine.run();
 
         assertTrue(ranAfterRender.get(), "After one render completes, the ranAfterRender boolean should have been set to true.");

--- a/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
+++ b/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
@@ -1,14 +1,6 @@
 package unittest.testcases.graphics.util;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Pointf;
-
 import tech.fastj.graphics.game.Polygon2D;
 import tech.fastj.graphics.util.DrawUtil;
 
@@ -26,6 +18,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DrawUtilTests {

--- a/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
+++ b/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
@@ -1,6 +1,14 @@
 package unittest.testcases.graphics.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import tech.fastj.math.Pointf;
+
 import tech.fastj.graphics.game.Polygon2D;
 import tech.fastj.graphics.util.DrawUtil;
 
@@ -18,13 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DrawUtilTests {

--- a/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
@@ -1,19 +1,16 @@
 package unittest.testcases.resources.models;
 
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import tech.fastj.engine.FastJEngine;
 import tech.fastj.math.Pointf;
-
 import tech.fastj.graphics.game.Model2D;
 import tech.fastj.graphics.game.Polygon2D;
 import tech.fastj.graphics.game.RenderStyle;
 import tech.fastj.graphics.gradients.Gradients;
 import tech.fastj.graphics.util.DrawUtil;
 
+import tech.fastj.resources.images.ImageResource;
+import tech.fastj.resources.images.ImageResourceManager;
 import tech.fastj.resources.models.ModelUtil;
 import tech.fastj.resources.models.SupportedModelFormats;
 
@@ -38,6 +35,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ObjMtlUtilTests {
@@ -215,6 +217,13 @@ class ObjMtlUtilTests {
     @Test
     @Order(2)
     void checkReadObj_shouldMatchOriginal() {
+        // TODO: either re-add resource managers on init() or don't remove them on exit()
+        // so that this monstrosity doesn't need to occur
+        try {
+            FastJEngine.getResourceManager(ImageResource.class);
+        } catch (IllegalStateException exception) {
+            FastJEngine.addResourceManager(new ImageResourceManager(), ImageResource.class);
+        }
         Polygon2D[] actualHouseArray = ModelUtil.loadModel(pathToModel);
         Model2D actualHouse = Model2D.create(actualHouseArray, false).build();
 
@@ -231,7 +240,7 @@ class ObjMtlUtilTests {
             }
 
             if (renderStyle == RenderStyle.Outline || renderStyle == RenderStyle.FillAndOutline) {
-                assertTrue(DrawUtil.outlineStrokeEquals(Polygon2D.DefaultOutlineStroke, actualHouseArray[i].getOutlineStroke()), "As a result of the loss of data exporting outline strokes to .obj, the polygon's outline stroke should now be the default.");
+                assertEquals(Polygon2D.DefaultOutlineStroke, actualHouseArray[i].getOutlineStroke(), "As a result of the loss of data exporting outline strokes to .obj, the polygon's outline stroke should now be the default.");
                 assertEquals(expectedHouseArray[i].getOutlineColor(), actualHouseArray[i].getOutlineColor(), "The created polygon's outline color should match the expected outline color.");
             }
 

--- a/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
@@ -1,8 +1,15 @@
 package unittest.testcases.resources.models;
 
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import tech.fastj.engine.FastJEngine;
+
 import tech.fastj.math.Pointf;
+
 import tech.fastj.graphics.game.Model2D;
 import tech.fastj.graphics.game.Polygon2D;
 import tech.fastj.graphics.game.RenderStyle;
@@ -35,11 +42,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ObjMtlUtilTests {


### PR DESCRIPTION
# Remove Redundant `DrawUtil.basicStrokeEquals` (and a few other cleanup things)


## Bug Fixes
- provided temporary fix to image resource manager being removed before `ObjMtlUtilTests` is able to use it -- needs attention before 1.6.0 release


## Breaking Changes
- removed `DrawUtil.basicStrokeEquals`. Instead, use the provided `equals` method from `BasicStroke`.


## Other Changes
- removed error log output from `FastJEngineTests` regarding `runAfterUpdate/Render`

