### PR TITLE
(resolves #159) move static imports in Spotless to the bottom of the list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,8 @@ spotless {
                 'tech.fastj.resources',
                 'tech.fastj.systems',
                 'java',
-                'javax'
+                'javax',
+                '\\#'
         )
         removeUnusedImports()
     }

--- a/src/test/java/unittest/testcases/engine/FastJEngineTests.java
+++ b/src/test/java/unittest/testcases/engine/FastJEngineTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.engine;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.engine.FastJEngine;
 import tech.fastj.engine.config.EngineConfig;
 import tech.fastj.engine.config.ExceptionAction;
@@ -23,6 +19,10 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FastJEngineTests {

--- a/src/test/java/unittest/testcases/engine/config/EngineConfigTests.java
+++ b/src/test/java/unittest/testcases/engine/config/EngineConfigTests.java
@@ -1,8 +1,5 @@
 package unittest.testcases.engine.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.engine.FastJEngine;
 import tech.fastj.engine.HWAccel;
 import tech.fastj.engine.config.EngineConfig;
@@ -15,6 +12,9 @@ import tech.fastj.logging.LogLevel;
 import unittest.EnvironmentHelper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class EngineConfigTests {
 

--- a/src/test/java/unittest/testcases/graphics/DrawableTests.java
+++ b/src/test/java/unittest/testcases/graphics/DrawableTests.java
@@ -1,10 +1,5 @@
 package unittest.testcases.graphics;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static unittest.EnvironmentHelper.runFastJWith;
-
 import tech.fastj.math.Pointf;
 
 import tech.fastj.graphics.Drawable;
@@ -21,6 +16,11 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static unittest.EnvironmentHelper.runFastJWith;
 
 class DrawableTests {
 

--- a/src/test/java/unittest/testcases/graphics/display/CameraTests.java
+++ b/src/test/java/unittest/testcases/graphics/display/CameraTests.java
@@ -1,7 +1,5 @@
 package unittest.testcases.graphics.display;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 import tech.fastj.math.Transform2D;
@@ -11,6 +9,8 @@ import tech.fastj.graphics.display.Camera;
 import java.awt.geom.AffineTransform;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CameraTests {
 

--- a/src/test/java/unittest/testcases/graphics/game/GameObjectTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/GameObjectTests.java
@@ -1,12 +1,5 @@
 package unittest.testcases.graphics.game;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 
 import tech.fastj.graphics.game.GameObject;
@@ -18,6 +11,13 @@ import unittest.mock.graphics.MockGameObject;
 import unittest.mock.systems.behaviors.MockBehavior;
 import unittest.mock.systems.control.MockEmptyScene;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GameObjectTests {
 

--- a/src/test/java/unittest/testcases/graphics/game/Model2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Model2DTests.java
@@ -1,8 +1,5 @@
 package unittest.testcases.graphics.game;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 import tech.fastj.math.Transform2D;
@@ -13,6 +10,9 @@ import tech.fastj.graphics.game.Polygon2D;
 import tech.fastj.graphics.util.DrawUtil;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class Model2DTests {
 

--- a/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.graphics.game;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 import tech.fastj.math.Transform2D;
@@ -18,6 +14,10 @@ import java.awt.Color;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class Polygon2DTests {
 

--- a/src/test/java/unittest/testcases/graphics/game/Text2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Text2DTests.java
@@ -1,10 +1,5 @@
 package unittest.testcases.graphics.game;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static unittest.EnvironmentHelper.runFastJWith;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 import tech.fastj.math.Transform2D;
@@ -21,6 +16,11 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static unittest.EnvironmentHelper.runFastJWith;
 
 class Text2DTests {
 

--- a/src/test/java/unittest/testcases/graphics/gradients/GradientsTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/GradientsTests.java
@@ -1,7 +1,5 @@
 package unittest.testcases.graphics.gradients;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 
@@ -18,6 +16,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class GradientsTests {
 

--- a/src/test/java/unittest/testcases/graphics/gradients/LinearGradientTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/LinearGradientTests.java
@@ -1,10 +1,5 @@
 package unittest.testcases.graphics.gradients;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 
@@ -19,6 +14,11 @@ import java.awt.Color;
 import java.awt.LinearGradientPaint;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LinearGradientTests {
 

--- a/src/test/java/unittest/testcases/graphics/gradients/RadialGradientTests.java
+++ b/src/test/java/unittest/testcases/graphics/gradients/RadialGradientTests.java
@@ -1,10 +1,5 @@
 package unittest.testcases.graphics.gradients;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Pointf;
 
@@ -15,6 +10,11 @@ import java.awt.Color;
 import java.awt.RadialGradientPaint;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RadialGradientTests {
 

--- a/src/test/java/unittest/testcases/graphics/ui/elements/ButtonTests.java
+++ b/src/test/java/unittest/testcases/graphics/ui/elements/ButtonTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.graphics.ui.elements;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.engine.FastJEngine;
 
 import tech.fastj.math.Maths;
@@ -22,6 +18,10 @@ import unittest.mock.systems.control.MockNameSettingScene;
 import unittest.mock.systems.control.MockSceneManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ButtonTests {
 

--- a/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
+++ b/src/test/java/unittest/testcases/graphics/util/DrawUtilTests.java
@@ -1,12 +1,5 @@
 package unittest.testcases.graphics.util;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Pointf;
 
 import tech.fastj.graphics.game.Polygon2D;
@@ -26,6 +19,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DrawUtilTests {

--- a/src/test/java/unittest/testcases/input/keyboard/KeysTests.java
+++ b/src/test/java/unittest/testcases/input/keyboard/KeysTests.java
@@ -1,12 +1,12 @@
 package unittest.testcases.input.keyboard;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
 import tech.fastj.input.keyboard.Keys;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class KeysTests {
 

--- a/src/test/java/unittest/testcases/logging/LogLevelTests.java
+++ b/src/test/java/unittest/testcases/logging/LogLevelTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.logging;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.engine.FastJEngine;
 
 import tech.fastj.logging.LogLevel;
@@ -11,6 +7,10 @@ import unittest.EnvironmentHelper;
 import unittest.mock.systems.control.MockEmptySimpleManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class LogLevelTests {
 

--- a/src/test/java/unittest/testcases/math/MathsTests.java
+++ b/src/test/java/unittest/testcases/math/MathsTests.java
@@ -1,13 +1,13 @@
 package unittest.testcases.math;
 
+import tech.fastj.math.Maths;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import tech.fastj.math.Maths;
-
-import org.junit.jupiter.api.Test;
 
 class MathsTests {
 

--- a/src/test/java/unittest/testcases/math/PointTests.java
+++ b/src/test/java/unittest/testcases/math/PointTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.math;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Point;
 import tech.fastj.math.Pointf;
@@ -15,6 +11,10 @@ import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PointTests {
 

--- a/src/test/java/unittest/testcases/math/PointfTests.java
+++ b/src/test/java/unittest/testcases/math/PointfTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.math;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.math.Maths;
 import tech.fastj.math.Point;
 import tech.fastj.math.Pointf;
@@ -15,6 +11,10 @@ import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PointfTests {
 

--- a/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
@@ -1,12 +1,6 @@
 package unittest.testcases.resources.models;
 
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.engine.FastJEngine;
 
 import tech.fastj.math.Pointf;
@@ -45,6 +39,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ObjMtlUtilTests {

--- a/src/test/java/unittest/testcases/resources/models/PsdfUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/PsdfUtilTests.java
@@ -1,9 +1,5 @@
 package unittest.testcases.resources.models;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import tech.fastj.math.Pointf;
 
 import tech.fastj.graphics.Boundary;
@@ -37,6 +33,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class PsdfUtilTests {

--- a/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
@@ -1,12 +1,5 @@
 package unittest.testcases.systems.audio;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.MemoryAudio;
 import tech.fastj.systems.audio.StreamedAudio;
@@ -23,6 +16,13 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AudioManagerTests {
 

--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -1,13 +1,5 @@
 package unittest.testcases.systems.audio;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import tech.fastj.math.Maths;
 
 import tech.fastj.systems.audio.AudioManager;
@@ -23,6 +15,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class MemoryAudioTests {
 

--- a/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/StreamedAudioTests.java
@@ -1,11 +1,5 @@
 package unittest.testcases.systems.audio;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.StreamedAudio;
 import tech.fastj.systems.audio.state.PlaybackState;
@@ -20,6 +14,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class StreamedAudioTests {
 

--- a/src/test/java/unittest/testcases/systems/control/SceneManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SceneManagerTests.java
@@ -1,11 +1,5 @@
 package unittest.testcases.systems.control;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import tech.fastj.systems.control.Scene;
 import tech.fastj.systems.control.SceneManager;
 
@@ -14,6 +8,12 @@ import unittest.mock.systems.control.MockEmptyScene;
 import unittest.mock.systems.control.MockNameSettingScene;
 import unittest.mock.systems.control.MockSceneManager;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class SceneManagerTests {
 

--- a/src/test/java/unittest/testcases/systems/control/SceneTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SceneTests.java
@@ -1,10 +1,5 @@
 package unittest.testcases.systems.control;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 import tech.fastj.graphics.game.GameObject;
@@ -17,6 +12,11 @@ import unittest.mock.graphics.MockDrawable;
 import unittest.mock.graphics.MockGameObject;
 import unittest.mock.systems.control.MockEmptyScene;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SceneTests {
 

--- a/src/test/java/unittest/testcases/systems/control/SimpleManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SimpleManagerTests.java
@@ -1,8 +1,5 @@
 package unittest.testcases.systems.control;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 import tech.fastj.graphics.game.GameObject;
@@ -15,6 +12,9 @@ import unittest.mock.graphics.MockDrawable;
 import unittest.mock.graphics.MockGameObject;
 import unittest.mock.systems.control.MockEmptySimpleManager;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class SimpleManagerTests {
 


### PR DESCRIPTION
# Move Static Imports to the Bottom of import list

resolves #159
