### PR TITLE
Curve support for Drawables

### DIFF
--- a/examples/java/tech/fastj/examples/behaviors/Main.java
+++ b/examples/java/tech/fastj/examples/behaviors/Main.java
@@ -59,7 +59,8 @@ public class Main extends SimpleManager {
          *
          * For this example, we'll just use simpleRotation. */
 
-        Polygon2D premadeBehaviorsBox = Polygon2D.create(DrawUtil.createBox(500f, 500f, 50f), RenderStyle.FillAndOutline)
+        Polygon2D premadeBehaviorsBox = Polygon2D.create(DrawUtil.createBox(500f, 500f, 50f))
+                .withRenderStyle(RenderStyle.FillAndOutline)
                 .withFill(Color.red)
                 .withOutline(Polygon2D.DefaultOutlineStroke, Polygon2D.DefaultOutlineColor)
                 .build();

--- a/examples/java/tech/fastj/examples/polygon2d/Main.java
+++ b/examples/java/tech/fastj/examples/polygon2d/Main.java
@@ -77,7 +77,8 @@ public class Main extends SimpleManager {
         float largeSquareRotation = 30f;
         Pointf largeSquareScale = new Pointf(0.5f, 0.5f);
 
-        Polygon2D largeSquare = Polygon2D.create(largeSquareMesh, RenderStyle.FillAndOutline)
+        Polygon2D largeSquare = Polygon2D.create(largeSquareMesh)
+                .withRenderStyle(RenderStyle.FillAndOutline)
                 .withFill(Color.blue)
                 .withOutline(largeSquareOutlineStroke, Color.black)
                 .withTransform(largeSquareTranslation, largeSquareRotation, largeSquareScale)

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -59,5 +59,6 @@ module fastj.library {
     exports tech.fastj.systems.audio.state;
     exports tech.fastj.systems.behaviors;
     exports tech.fastj.systems.control;
+    exports tech.fastj.systems.collections;
     exports tech.fastj.systems.tags;
 }

--- a/src/main/java/tech/fastj/graphics/game/Polygon2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Polygon2D.java
@@ -72,64 +72,51 @@ public class Polygon2D extends GameObject {
 
     /**
      * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points} field.
-     * <p>
      *
      * @param points {@code Pointf} array that defines the points for the {@code Polygon2D}.
      * @return A {@code Polygon2DBuilder} instance for creating a {@code Polygon2D}.
      */
     public static Polygon2DBuilder create(Pointf[] points) {
-        return new Polygon2DBuilder(points, null, DefaultRenderStyle, Drawable.DefaultShouldRender);
+        return new Polygon2DBuilder(points, null, Drawable.DefaultShouldRender);
     }
 
     /**
-     * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points} field.
-     * <p>
+     * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points} and
+     * {@code altIndexes} fields.
      *
-     * @param points {@code Pointf} array that defines the points for the {@code Polygon2D}.
+     * @param points     {@code Pointf} array that defines the points for the {@code Polygon2D}.
+     * @param altIndexes The {@code Point} array of alternate indexes defining where curves are in the array of points,
+     *                   as well as other {@code Path2D} options.
      * @return A {@code Polygon2DBuilder} instance for creating a {@code Polygon2D}.
      */
     public static Polygon2DBuilder create(Pointf[] points, Point[] altIndexes) {
-        return new Polygon2DBuilder(points, altIndexes, DefaultRenderStyle, Drawable.DefaultShouldRender);
+        return new Polygon2DBuilder(points, altIndexes, Drawable.DefaultShouldRender);
     }
 
     /**
      * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points} and
      * {@code shouldRender} fields.
-     * <p>
      *
      * @param points       {@code Pointf} array that defines the points for the {@code Polygon2D}.
      * @param shouldRender {@code boolean} that defines whether the {@code Polygon2D} would be rendered to the screen.
      * @return A {@code Polygon2DBuilder} instance for creating a {@code Polygon2D}.
      */
     public static Polygon2DBuilder create(Pointf[] points, boolean shouldRender) {
-        return new Polygon2DBuilder(points, null, DefaultRenderStyle, shouldRender);
-    }
-
-    /**
-     * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points} and
-     * {@code renderStyle} fields.
-     * <p>
-     *
-     * @param points      {@code Pointf} array that defines the points for the {@code Polygon2D}.
-     * @param renderStyle {@code RenderStyle} that defines the render style for the {@code Polygon2D}.
-     * @return A {@code Polygon2DBuilder} instance for creating a {@code Polygon2D}.
-     */
-    public static Polygon2DBuilder create(Pointf[] points, RenderStyle renderStyle) {
-        return new Polygon2DBuilder(points, null, renderStyle, Drawable.DefaultShouldRender);
+        return new Polygon2DBuilder(points, null, shouldRender);
     }
 
     /**
      * Gets a {@link Polygon2DBuilder} instance while setting the eventual {@link Polygon2D}'s {@code points},
      * {@code renderStyle}, and {@code shouldRender} fields.
-     * <p>
      *
      * @param points       {@code Pointf} array that defines the points for the {@code Polygon2D}.
-     * @param renderStyle  {@code RenderStyle} that defines the render style for the {@code Polygon2D}.
+     * @param altIndexes   The {@code Point} array of alternate indexes defining where curves are in the array of
+     *                     points, as well as other {@code Path2D} options.
      * @param shouldRender {@code boolean} that defines whether the {@code Polygon2D} would be rendered to the screen.
      * @return A {@code Polygon2DBuilder} instance for creating a {@code Polygon2D}.
      */
-    public static Polygon2DBuilder create(Pointf[] points, RenderStyle renderStyle, boolean shouldRender) {
-        return new Polygon2DBuilder(points, null, renderStyle, shouldRender);
+    public static Polygon2DBuilder create(Pointf[] points, Point[] altIndexes, boolean shouldRender) {
+        return new Polygon2DBuilder(points, altIndexes, shouldRender);
     }
 
     /**
@@ -139,17 +126,19 @@ public class Polygon2D extends GameObject {
      * @return The resulting {@code Polygon2D}.
      */
     public static Polygon2D fromPoints(Pointf[] points) {
-        return new Polygon2DBuilder(points, null, DefaultRenderStyle, Drawable.DefaultShouldRender).build();
+        return new Polygon2DBuilder(points, null, Drawable.DefaultShouldRender).build();
     }
 
     /**
-     * Creates a {@code Polygon2D} from the specified points.
+     * Creates a {@code Polygon2D} from the specified points and alternate indexes.
      *
-     * @param points {@code Pointf} array that defines the points for the {@code Polygon2D}.
+     * @param points     {@code Pointf} array that defines the points for the {@code Polygon2D}.
+     * @param altIndexes The {@code Point} array of alternate indexes defining where curves are in the array of points,
+     *                   as well as other {@code Path2D} options.
      * @return The resulting {@code Polygon2D}.
      */
     public static Polygon2D fromPoints(Pointf[] points, Point[] altIndexes) {
-        return new Polygon2DBuilder(points, altIndexes, DefaultRenderStyle, Drawable.DefaultShouldRender).build();
+        return new Polygon2DBuilder(points, altIndexes, Drawable.DefaultShouldRender).build();
     }
 
     /**
@@ -163,7 +152,7 @@ public class Polygon2D extends GameObject {
 
     /**
      * Gets the polygon's alternate indexes, which are associated with the
-     * {@link #getOriginalPoints() original point set.}
+     * {@link #getOriginalPoints() original point set}.
      *
      * @return The original set of points for this polygon, as a {@code Pointf[]}.
      */

--- a/src/main/java/tech/fastj/graphics/game/Polygon2DBuilder.java
+++ b/src/main/java/tech/fastj/graphics/game/Polygon2DBuilder.java
@@ -15,8 +15,8 @@ public class Polygon2DBuilder {
     private final Pointf[] points;
     private final Point[] altIndexes;
     private final boolean shouldRender;
-    private final RenderStyle renderStyle;
 
+    private RenderStyle renderStyle = Polygon2D.DefaultRenderStyle;
     private Paint fillPaint = Polygon2D.DefaultFill;
     private BasicStroke outlineStroke = Polygon2D.DefaultOutlineStroke;
     private Color outlineColor = Polygon2D.DefaultOutlineColor;
@@ -26,18 +26,29 @@ public class Polygon2DBuilder {
     private Pointf scale = Transform2D.DefaultScale.copy();
 
     /**
-     * {@code Polygon2DBuilder} constructor, taking in a set of points, a render style, and a {@code shouldRender}
-     * boolean.
+     * {@code Polygon2DBuilder} constructor, taking in a set of points, a set of alternate indexes (for defining
+     * curves), and a {@code shouldRender} boolean.
      *
      * @param points       The {@code Pointf} array of mesh points to use for the resulting {@code Polygon2D}.
-     * @param renderStyle  The {@code RenderStyle} to use for the resulting {@code Polygon2D}.
+     * @param altIndexes   The {@code Point} array of alternate indexes defining where curves are in the array of
+     *                     points, as well as other {@code Path2D} options.
      * @param shouldRender The "should render" {@code boolean} to use for the resulting {@code Polygon2D}.
      */
-    Polygon2DBuilder(Pointf[] points, Point[] altIndexes, RenderStyle renderStyle, boolean shouldRender) {
+    Polygon2DBuilder(Pointf[] points, Point[] altIndexes, boolean shouldRender) {
         this.points = Objects.requireNonNull(points, "The array of points must not be null.");
         this.altIndexes = altIndexes;
-        this.renderStyle = Objects.requireNonNull(renderStyle, "The render style must not be null.");
         this.shouldRender = shouldRender;
+    }
+
+    /**
+     * Sets the builder's render style value.
+     *
+     * @param renderStyle The {@code RenderStyle} to be used in the resulting {@code Polygon2D}.
+     * @return The {@code Polygon2DBuilder}, for method chaining.
+     */
+    public Polygon2DBuilder withRenderStyle(RenderStyle renderStyle) {
+        this.renderStyle = Objects.requireNonNull(renderStyle, "The render style must not be null.");
+        return this;
     }
 
     /**

--- a/src/main/java/tech/fastj/graphics/game/Polygon2DBuilder.java
+++ b/src/main/java/tech/fastj/graphics/game/Polygon2DBuilder.java
@@ -1,5 +1,6 @@
 package tech.fastj.graphics.game;
 
+import tech.fastj.math.Point;
 import tech.fastj.math.Pointf;
 import tech.fastj.math.Transform2D;
 
@@ -12,6 +13,7 @@ import java.util.Objects;
 public class Polygon2DBuilder {
 
     private final Pointf[] points;
+    private final Point[] altIndexes;
     private final boolean shouldRender;
     private final RenderStyle renderStyle;
 
@@ -31,8 +33,9 @@ public class Polygon2DBuilder {
      * @param renderStyle  The {@code RenderStyle} to use for the resulting {@code Polygon2D}.
      * @param shouldRender The "should render" {@code boolean} to use for the resulting {@code Polygon2D}.
      */
-    Polygon2DBuilder(Pointf[] points, RenderStyle renderStyle, boolean shouldRender) {
+    Polygon2DBuilder(Pointf[] points, Point[] altIndexes, RenderStyle renderStyle, boolean shouldRender) {
         this.points = Objects.requireNonNull(points, "The array of points must not be null.");
+        this.altIndexes = altIndexes;
         this.renderStyle = Objects.requireNonNull(renderStyle, "The render style must not be null.");
         this.shouldRender = shouldRender;
     }
@@ -85,7 +88,7 @@ public class Polygon2DBuilder {
      * @return The resulting {@code Polygon2D}.
      */
     public Polygon2D build() {
-        return (Polygon2D) new Polygon2D(points)
+        return (Polygon2D) new Polygon2D(points, altIndexes)
                 .setOutlineStroke(outlineStroke)
                 .setOutlineColor(outlineColor)
                 .setRenderStyle(renderStyle)

--- a/src/main/java/tech/fastj/resources/models/ObjUtil.java
+++ b/src/main/java/tech/fastj/resources/models/ObjUtil.java
@@ -69,7 +69,7 @@ public class ObjUtil {
                         polygons.get(lastPolygonIndex).setRenderStyle(RenderStyle.FillAndOutline);
                         MtlUtil.parse(polygons.get(lastPolygonIndex), materialLibraryPath, currentMaterial, false);
                     } else {
-                        Polygon2D polygonFromVertexes = Polygon2D.create(vertexesFromFaces, RenderStyle.Outline).build();
+                        Polygon2D polygonFromVertexes = Polygon2D.create(vertexesFromFaces).withRenderStyle(RenderStyle.Outline).build();
                         MtlUtil.parse(polygonFromVertexes, materialLibraryPath, currentMaterial, false);
                         polygons.add(polygonFromVertexes);
                     }

--- a/src/main/java/tech/fastj/resources/models/ObjUtil.java
+++ b/src/main/java/tech/fastj/resources/models/ObjUtil.java
@@ -55,6 +55,7 @@ public class ObjUtil {
                     Pointf[] vertexesFromFaces = new Pointf[tokens.length - 1];
                     boolean isLastPolygonOutline = false;
                     int lastPolygonIndex = polygons.size() - 1;
+                    Pointf[] lastPolygonPoints = polygons.get(lastPolygonIndex).getPoints();
 
                     for (int j = 0; j < tokens.length - 1; j++) {
                         int vertexesIndex = Integer.parseInt(tokens[j + 1].split("/")[0]);
@@ -62,7 +63,7 @@ public class ObjUtil {
                                 vertexes.get(vertexesIndex - 1)[0],
                                 vertexes.get(vertexesIndex - 1)[1]
                         );
-                        isLastPolygonOutline = polygons.get(lastPolygonIndex).getPoints()[j].equals(vertexesFromFaces[j]);
+                        isLastPolygonOutline = lastPolygonPoints[j].equals(vertexesFromFaces[j]);
                     }
 
                     if (isLastPolygonOutline) {
@@ -150,7 +151,7 @@ public class ObjUtil {
             writeObject(fileContents, i + 1);
             writeMaterial(fileContents, polygon, i + 1, vertexCount);
 
-            vertexCount += polygon.getPoints().length;
+            vertexCount += polygon.getOriginalPoints().length;
         }
 
         try {
@@ -175,8 +176,8 @@ public class ObjUtil {
 
     private static void writeVertexes(StringBuilder fileContents, Polygon2D polygon, int polygonIndex) {
         float vertexSpace = polygonIndex / 1000f;
-        for (int j = 0; j < polygon.getPoints().length; j++) {
-            Pointf vertex = polygon.getPoints()[j];
+        Pointf[] polygonPoints = polygon.getPoints();
+        for (Pointf vertex : polygonPoints) {
             fileContents.append(ParsingKeys.Vertex)
                     .append(' ')
                     .append(String.format("%4f", vertex.x))
@@ -192,9 +193,10 @@ public class ObjUtil {
         Pointf space = Pointf.subtract(polygon.getBound(Boundary.BottomRight), polygon.getBound(Boundary.TopLeft));
         Pointf topLeft = polygon.getBound(Boundary.TopLeft);
 
-        for (int j = 0; j < polygon.getPoints().length; j++) {
-            float circleX = Maths.normalize(polygon.getPoints()[j].x - topLeft.x, 0f, space.x);
-            float circleY = Maths.normalize(polygon.getPoints()[j].y - topLeft.y, 0f, space.y);
+        Pointf[] polygonPoints = polygon.getPoints();
+        for (Pointf polygonPoint : polygonPoints) {
+            float circleX = Maths.normalize(polygonPoint.x - topLeft.x, 0f, space.x);
+            float circleY = Maths.normalize(polygonPoint.y - topLeft.y, 0f, space.y);
             fileContents.append(ParsingKeys.VertexTexture)
                     .append(' ')
                     .append(String.format("%4f", circleX))
@@ -253,7 +255,8 @@ public class ObjUtil {
 
     private static void writeFaces(StringBuilder fileContents, Polygon2D polygon, int vertexCount) {
         fileContents.append(ParsingKeys.ObjectFace);
-        for (int i = 1; i <= polygon.getPoints().length; i++) {
+        Pointf[] polygonPoints = polygon.getPoints();
+        for (int i = 1; i <= polygonPoints.length; i++) {
             fileContents.append(' ')
                     .append(vertexCount + i)
                     .append('/')
@@ -264,7 +267,8 @@ public class ObjUtil {
 
     private static void writeLines(StringBuilder fileContents, Polygon2D polygon, int vertexCount) {
         fileContents.append(ParsingKeys.ObjectLine);
-        for (int i = 1; i <= polygon.getPoints().length; i++) {
+        Pointf[] polygonPoints = polygon.getPoints();
+        for (int i = 1; i <= polygonPoints.length; i++) {
             fileContents.append(' ').append(vertexCount + i);
         }
         fileContents.append(LineSeparator);

--- a/src/main/java/tech/fastj/resources/models/PsdfUtil.java
+++ b/src/main/java/tech/fastj/resources/models/PsdfUtil.java
@@ -109,7 +109,8 @@ public class PsdfUtil {
                     if (tokens.length == 4 && tokens[3].equals(";")) {
                         assert polygons != null;
 
-                        polygons[polygonsIndex] = Polygon2D.create(polygonPoints.toArray(new Pointf[0]), renderStyle, shouldRender)
+                        polygons[polygonsIndex] = Polygon2D.create(polygonPoints.toArray(new Pointf[0]), null, shouldRender)
+                                .withRenderStyle(renderStyle)
                                 .withOutline(outlineStroke, outlineColor)
                                 .withTransform(translation, rotation, scale)
                                 .build();

--- a/src/main/java/tech/fastj/systems/collections/Pair.java
+++ b/src/main/java/tech/fastj/systems/collections/Pair.java
@@ -1,0 +1,53 @@
+package tech.fastj.systems.collections;
+
+import java.util.Objects;
+
+/**
+ * 2-tuple generic class.
+ * <p>
+ * This implementation does not provide comparisons or well-established, veritable solutions for tuples. It only
+ * provides the necessities to easily return two values at once. If you would like a well-made tuple system, go use
+ * Apache Commons' libraries.
+ *
+ * @param <L> The type for the left parameter of the pair.
+ * @param <R> The type for the right parameter of the pair.
+ */
+public class Pair<L, R> {
+
+    private final L left;
+    private final R right;
+
+    public Pair(L left, R right) {
+        this.left = Objects.requireNonNull(left);
+        this.right = Objects.requireNonNull(right);
+    }
+
+    public L getLeft() {
+        return left;
+    }
+
+    public R getRight() {
+        return right;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        Pair<?, ?> pair = (Pair<?, ?>) other;
+        return left.equals(pair.left) && right.equals(pair.right);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right);
+    }
+
+    public static <L, R> Pair<L, R> of(L left, R right) {
+        return new Pair<>(left, right);
+    }
+}

--- a/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
@@ -45,7 +45,8 @@ class Polygon2DTests {
         RenderStyle renderStyle = RenderStyle.values()[Maths.randomInteger(0, RenderStyle.values().length - 1)];
         boolean shouldRender = Maths.randomBoolean();
 
-        Polygon2D polygon2D = Polygon2D.create(square, renderStyle, shouldRender)
+        Polygon2D polygon2D = Polygon2D.create(square, shouldRender)
+                .withRenderStyle(renderStyle)
                 .withFill(randomColor)
                 .build();
 
@@ -75,8 +76,9 @@ class Polygon2DTests {
         float randomRotation = Maths.random(-5000f, 5000f);
         float expectedNormalizedRotation = randomRotation % 360;
 
-        Polygon2D polygon2D = Polygon2D.create(square, renderStyle, shouldRender)
+        Polygon2D polygon2D = Polygon2D.create(square, shouldRender)
                 .withTransform(randomTranslation, randomRotation, randomScale)
+                .withRenderStyle(renderStyle)
                 .withOutline(outlineStroke, outlineColor)
                 .withFill(randomColor)
                 .build();

--- a/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/ObjMtlUtilTests.java
@@ -60,7 +60,8 @@ class ObjMtlUtilTests {
     private static final RenderStyle expectedHouseWallsRenderStyle = RenderStyle.FillAndOutline;
     private static final BasicStroke expectedHouseWallsOutlineStroke = new BasicStroke(5.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 15f);
     private static final Color expectedHouseWallsOutlineColor = new Color(150, 150, 150, 150);
-    private static final Polygon2D expectedHouseWalls = Polygon2D.create(expectedHouseWallsMesh, expectedHouseWallsRenderStyle)
+    private static final Polygon2D expectedHouseWalls = Polygon2D.create(expectedHouseWallsMesh)
+            .withRenderStyle(expectedHouseWallsRenderStyle)
             .withOutline(expectedHouseWallsOutlineStroke, expectedHouseWallsOutlineColor)
             .build();
     private static final RadialGradientPaint expectedHouseWallsGradient = Gradients.radialGradient(expectedHouseWalls)
@@ -75,7 +76,8 @@ class ObjMtlUtilTests {
     };
     private static final RenderStyle expectedHouseRoofRenderStyle = RenderStyle.Outline;
     private static final BasicStroke expectedHouseRoofOutlineStroke = new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0.0f);
-    private static final Polygon2D expectedHouseRoof = Polygon2D.create(expectedHouseRoofMesh, expectedHouseRoofRenderStyle)
+    private static final Polygon2D expectedHouseRoof = Polygon2D.create(expectedHouseRoofMesh)
+            .withRenderStyle(expectedHouseRoofRenderStyle)
             .withOutline(expectedHouseRoofOutlineStroke, Polygon2D.DefaultOutlineColor)
             .build();
 

--- a/src/test/java/unittest/testcases/resources/models/PsdfUtilTests.java
+++ b/src/test/java/unittest/testcases/resources/models/PsdfUtilTests.java
@@ -51,7 +51,8 @@ class PsdfUtilTests {
     private static final RenderStyle expectedHouseWallsRenderStyle = RenderStyle.FillAndOutline;
     private static final BasicStroke expectedHouseWallsOutlineStroke = new BasicStroke(5.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 15f);
     private static final Color expectedHouseWallsOutlineColor = new Color(150, 150, 150, 150);
-    private static final Polygon2D expectedHouseWalls = Polygon2D.create(expectedHouseWallsMesh, expectedHouseWallsRenderStyle)
+    private static final Polygon2D expectedHouseWalls = Polygon2D.create(expectedHouseWallsMesh)
+            .withRenderStyle(expectedHouseWallsRenderStyle)
             .withOutline(expectedHouseWallsOutlineStroke, expectedHouseWallsOutlineColor)
             .build();
     private static final RadialGradientPaint expectedHouseWallsGradient = Gradients.radialGradient(expectedHouseWalls)
@@ -66,7 +67,8 @@ class PsdfUtilTests {
     };
     private static final RenderStyle expectedHouseRoofRenderStyle = RenderStyle.Outline;
     private static final BasicStroke expectedHouseRoofOutlineStroke = new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0.0f);
-    private static final Polygon2D expectedHouseRoof = Polygon2D.create(expectedHouseRoofMesh, expectedHouseRoofRenderStyle)
+    private static final Polygon2D expectedHouseRoof = Polygon2D.create(expectedHouseRoofMesh)
+            .withRenderStyle(expectedHouseRoofRenderStyle)
             .withOutline(expectedHouseRoofOutlineStroke, Polygon2D.DefaultOutlineColor)
             .build();
     private static final LinearGradientPaint expectedHouseRoofGradient = Gradients.linearGradient(expectedHouseRoof, Boundary.TopLeft, Boundary.BottomRight)


### PR DESCRIPTION
# Curve Support for Drawable

Closes #109, related to #10

## Additions
- Created Pair class to handle returning 2 values at once, for generating point meshes with curves.
- Support for converting Path2D objects with curves and multiple subpaths to Pointf[] arrays (with optional `alternateIndexes` stored in paired `Point[]`)
- `DrawUtil#pointsOfPathWithAlt` specifically for getting both the points of the path and indicators of where curves/other path related functions are
- Support for writing/reading polygons with curves with .psdf files.


## Breaking Changes
- Removed RenderStyle from Polygon2DBuilder constructors, as well as other Polygon2D static methods. Instead, it is configured from `Polygon2DBuilder#withRenderStyle(RenderStyle)`.
- `DrawUtil#pointsOfPath` and variants no longer throw exceptions on unclosed paths.


## Other Changes
- Optimized usages of `Polygon2D#getPoints` to be less taxing for standard tasks

