### PR TITLE
Create Polygon2D from Path2D, bugfix on DrawUtil#lengthOfPath

### DIFF
--- a/src/main/java/tech/fastj/graphics/game/Polygon2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Polygon2D.java
@@ -6,6 +6,7 @@ import tech.fastj.math.Pointf;
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.util.DrawUtil;
 
+import tech.fastj.systems.collections.Pair;
 import tech.fastj.systems.control.Scene;
 import tech.fastj.systems.control.SimpleManager;
 
@@ -139,6 +140,17 @@ public class Polygon2D extends GameObject {
      */
     public static Polygon2D fromPoints(Pointf[] points, Point[] altIndexes) {
         return new Polygon2DBuilder(points, altIndexes, Drawable.DefaultShouldRender).build();
+    }
+
+    /**
+     * Creates a {@code Polygon2D} from the specified {@link Path2D.Float}.
+     *
+     * @param path {@code Path2D.Float} that defines the points from which to create a {@code Polygon2D}.
+     * @return The resulting {@code Polygon2D}.
+     */
+    public static Polygon2D fromPath(Path2D.Float path) {
+        Pair<Pointf[], Point[]> pathMesh = DrawUtil.pointsOfPathWithAlt(path);
+        return new Polygon2DBuilder(pathMesh.getLeft(), pathMesh.getRight(), Drawable.DefaultShouldRender).build();
     }
 
     /**

--- a/src/main/java/tech/fastj/graphics/util/DrawUtil.java
+++ b/src/main/java/tech/fastj/graphics/util/DrawUtil.java
@@ -672,7 +672,7 @@ public final class DrawUtil {
      */
     public static int lengthOfPath(Path2D path) {
         int count = 0;
-        double[] coords = new double[2];
+        double[] coords = new double[6];
 
         int numSubPaths = 0;
 

--- a/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
+++ b/src/test/java/unittest/testcases/graphics/game/Polygon2DTests.java
@@ -11,6 +11,7 @@ import tech.fastj.graphics.util.DrawUtil;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.geom.Path2D;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,28 @@ class Polygon2DTests {
         assertEquals(Transform2D.DefaultRotation, polygon2D.getRotation(), "The created polygon's rotation should match an origin rotation.");
         assertEquals(Transform2D.DefaultScale, polygon2D.getScale(), "The created polygon's scaling should match an origin scale.");
         assertArrayEquals(square, polygon2D.getOriginalPoints(), "The created polygon's Pointf array should match the original Pointf array.");
+    }
+    @Test
+    void checkPolygon2DCreation_withPath2DParam() {
+        Path2D.Float path = new Path2D.Float();
+        path.moveTo(0f, 0f);
+        path.lineTo(10f, 0f);
+        path.curveTo(6f, 3f, 14f, 7f, 10f, 10f);
+        path.lineTo(0f, 10f);
+        path.quadTo(5f, 5f, 0f, 0f);
+        path.closePath();
+        Polygon2D polygon2D = Polygon2D.fromPath(path);
+
+        assertEquals(Polygon2D.DefaultFill, polygon2D.getFill(), "The created polygon's paint should match the default paint.");
+        assertEquals(Polygon2D.DefaultRenderStyle, polygon2D.getRenderStyle(), "The created polygon's render style option should match the default render style.");
+        assertEquals(Drawable.DefaultShouldRender, polygon2D.shouldRender(), "The created polygon's 'show' option should match the default shouldRender option.");
+        assertEquals(Polygon2D.DefaultOutlineStroke, polygon2D.getOutlineStroke(), "The created polygon's outline stroke option should match the default outline stroke.");
+        assertEquals(Polygon2D.DefaultOutlineColor, polygon2D.getOutlineColor(), "The created polygon's outline color option should match the default outline color.");
+        assertEquals(Transform2D.DefaultTranslation, polygon2D.getTranslation(), "The created polygon's translation should match an origin translation.");
+        assertEquals(Transform2D.DefaultRotation, polygon2D.getRotation(), "The created polygon's rotation should match an origin rotation.");
+        assertEquals(Transform2D.DefaultScale, polygon2D.getScale(), "The created polygon's scaling should match an origin scale.");
+        assertArrayEquals(DrawUtil.pointsOfPath(path), polygon2D.getOriginalPoints(), "The created polygon's Pointf array should match the path's original Pointf array.");
+        assertArrayEquals(DrawUtil.pointsOfPathWithAlt(path).getRight(), polygon2D.getAlternateIndexes(), "The created polygon's Pointf alternate indexes should match the expected alternate indexes.");
     }
 
     @Test


### PR DESCRIPTION
# Create Polygon2D from Path2D, bugfix on `DrawUtil#lengthOfPath`

## Additions
- Added `Polygon2D#fromPath` to allow creation of `Polygon2D` objects from `Path2D.Float` objects
- Added unit tests for some curve-related methods

## Bug Fixes
- Fixed issue where `DrawUtil#lengthOfPath` would crash when attempting to read curves
