### PR TITLE
too many bug fixes

### DIFF
--- a/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
@@ -76,7 +76,6 @@ public class PlayerHealthBar implements Behavior {
                 FastJEngine.runAfterUpdate(() -> {
                     SceneManager sceneManager = FastJEngine.getLogicManager();
                     sceneManager.switchScenes(SceneNames.LoseSceneName);
-                    sceneManager.getScene(SceneNames.GameSceneName).unload(FastJEngine.getCanvas());
                 });
             }
         }

--- a/src/main/java/tech/fastj/animation/event/AnimationEvent.java
+++ b/src/main/java/tech/fastj/animation/event/AnimationEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.gameloop.event.GameEvent;
 import tech.fastj.animation.Animated;
 import tech.fastj.animation.AnimationData;
 
-public interface AnimationEvent<TD extends AnimationData, T extends Animated<TD>> extends GameEvent {
+public abstract class AnimationEvent<TD extends AnimationData, T extends Animated<TD>> extends GameEvent {
 
-    T getEventSource();
+    public abstract T getEventSource();
 }

--- a/src/main/java/tech/fastj/animation/sprite/event/AnimationChangeEvent.java
+++ b/src/main/java/tech/fastj/animation/sprite/event/AnimationChangeEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.animation.Animated;
 import tech.fastj.animation.event.AnimationEvent;
 import tech.fastj.animation.sprite.SpriteAnimationData;
 
-public class AnimationChangeEvent<TD extends SpriteAnimationData, T extends Animated<TD>> implements AnimationEvent<TD, T> {
+public class AnimationChangeEvent<TD extends SpriteAnimationData, T extends Animated<TD>> extends AnimationEvent<TD, T> {
 
     private final T eventSource;
     private final TD oldAnimationData;

--- a/src/main/java/tech/fastj/animation/sprite/event/AnimationFlipEvent.java
+++ b/src/main/java/tech/fastj/animation/sprite/event/AnimationFlipEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.animation.Animated;
 import tech.fastj.animation.event.AnimationEvent;
 import tech.fastj.animation.sprite.SpriteAnimationData;
 
-public class AnimationFlipEvent<TD extends SpriteAnimationData, T extends Animated<TD>> implements AnimationEvent<TD, T> {
+public class AnimationFlipEvent<TD extends SpriteAnimationData, T extends Animated<TD>> extends AnimationEvent<TD, T> {
 
     private final T eventSource;
     private final TD animationData;

--- a/src/main/java/tech/fastj/animation/sprite/event/AnimationLoopEvent.java
+++ b/src/main/java/tech/fastj/animation/sprite/event/AnimationLoopEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.animation.Animated;
 import tech.fastj.animation.event.AnimationEvent;
 import tech.fastj.animation.sprite.SpriteAnimationData;
 
-public class AnimationLoopEvent<TD extends SpriteAnimationData, T extends Animated<TD>> implements AnimationEvent<TD, T> {
+public class AnimationLoopEvent<TD extends SpriteAnimationData, T extends Animated<TD>> extends AnimationEvent<TD, T> {
 
     private final T eventSource;
     private final TD animationData;

--- a/src/main/java/tech/fastj/animation/sprite/event/AnimationPauseEvent.java
+++ b/src/main/java/tech/fastj/animation/sprite/event/AnimationPauseEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.animation.Animated;
 import tech.fastj.animation.event.AnimationEvent;
 import tech.fastj.animation.sprite.SpriteAnimationData;
 
-public class AnimationPauseEvent<TD extends SpriteAnimationData, T extends Animated<TD>> implements AnimationEvent<TD, T> {
+public class AnimationPauseEvent<TD extends SpriteAnimationData, T extends Animated<TD>> extends AnimationEvent<TD, T> {
 
     private final T eventSource;
     private final TD animationData;

--- a/src/main/java/tech/fastj/animation/sprite/event/AnimationPlayEvent.java
+++ b/src/main/java/tech/fastj/animation/sprite/event/AnimationPlayEvent.java
@@ -4,7 +4,7 @@ import tech.fastj.animation.Animated;
 import tech.fastj.animation.event.AnimationEvent;
 import tech.fastj.animation.sprite.SpriteAnimationData;
 
-public class AnimationPlayEvent<TD extends SpriteAnimationData, T extends Animated<TD>> implements AnimationEvent<TD, T> {
+public class AnimationPlayEvent<TD extends SpriteAnimationData, T extends Animated<TD>> extends AnimationEvent<TD, T> {
 
     private final T eventSource;
     private final TD animationData;

--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -220,6 +220,10 @@ public class FastJEngine {
         addDefaultResourceManagers();
         addDefaultAnimationEngines();
 
+        initGameLoop();
+    }
+
+    private static void initGameLoop() {
         GameLoop.addGameLoopStates(GeneralFixedUpdate, BehaviorFixedUpdate, AfterFixedUpdate);
         GameLoop.addGameLoopStates(ProcessInputEvents, ProcessKeysDown, GeneralUpdate, BehaviorUpdate, AnimationStep);
         GameLoop.addGameLoopStates(GeneralRender, AfterRender);
@@ -855,9 +859,7 @@ public class FastJEngine {
 
         // game loop
         GameLoop.reset();
-        GameLoop.addGameLoopStates(GeneralFixedUpdate, BehaviorFixedUpdate, AfterFixedUpdate);
-        GameLoop.addGameLoopStates(ProcessInputEvents, ProcessKeysDown, GeneralUpdate, BehaviorUpdate, AnimationStep);
-        GameLoop.addGameLoopStates(GeneralRender, AfterRender);
+        initGameLoop();
 
         // Check values
         isRunning = false;

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -190,6 +190,7 @@ public class GameLoop implements Runnable {
             ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
             return;
         }
+        System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
 
         List<GameEventObserver<? extends GameEvent>> gameEventObserverList = gameEventObservers.get(eventClass);
         if (gameEventObserverList == null) {
@@ -302,6 +303,7 @@ public class GameLoop implements Runnable {
             ((GameEventHandler) gameEventHandler).handleEvents(gameEventObservers.get(eventClass), gameEvents);
             return;
         }
+        System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
 
         while (!gameEvents.isEmpty()) {
             GameEvent nextEvent = gameEvents.poll();

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -1,14 +1,15 @@
 package tech.fastj.gameloop;
 
 import tech.fastj.logging.Log;
-import tech.fastj.gameloop.event.GameEvent;
-import tech.fastj.gameloop.event.GameEventHandler;
-import tech.fastj.gameloop.event.GameEventObserver;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+
+import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.GameEventHandler;
+import tech.fastj.gameloop.event.GameEventObserver;
 
 public class GameLoop implements Runnable {
 
@@ -199,9 +200,10 @@ public class GameLoop implements Runnable {
 
     @SuppressWarnings("unchecked")
     public <T extends GameEvent> void fireEvent(T event) {
-        Class<T> eventClass = (Class<T>) event.getClass();
         Set<Object> alreadyViewed = new HashSet<>();
         Set<Object> handlerAlreadyViewed = new HashSet<>();
+
+        Class<T> eventClass = (Class<T>) event.getClass();
         tryFireEvent(event, eventClass, alreadyViewed, handlerAlreadyViewed);
 
 
@@ -209,6 +211,9 @@ public class GameLoop implements Runnable {
         if (classAlias != null) {
             tryFireEvent(event, classAlias, alreadyViewed, handlerAlreadyViewed);
         }
+
+        alreadyViewed.clear();
+        handlerAlreadyViewed.clear();
     }
 
     @SuppressWarnings("unchecked")
@@ -234,11 +239,10 @@ public class GameLoop implements Runnable {
         }
 
         for (var gameEventObserver : gameEventObserverList) {
-            if (!alreadyViewedEvent.add(gameEventObserver)) {
-                continue;
+            if (alreadyViewedEvent.add(gameEventObserver)) {
+                ((GameEventObserver<T>) gameEventObserver).eventReceived(event);
             }
 
-            ((GameEventObserver<T>) gameEventObserver).eventReceived(event);
         }
     }
 

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -199,22 +199,20 @@ public class GameLoop implements Runnable {
     @SuppressWarnings("unchecked")
     public <T extends GameEvent> void fireEvent(T event) {
         Class<T> eventClass = (Class<T>) event.getClass();
-        boolean success = tryFireEvent(event, eventClass);
+        tryFireEvent(event, eventClass);
 
-        if (!success) {
-            Class<GameEvent> classAlias = (Class<GameEvent>) classAliases.get(eventClass);
-            if (classAlias != null) {
-                tryFireEvent(event, classAlias);
-            }
+        Class<GameEvent> classAlias = (Class<GameEvent>) classAliases.get(eventClass);
+        if (classAlias != null) {
+            tryFireEvent(event, classAlias);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends GameEvent> boolean tryFireEvent(T event, Class<T> eventClass) {
+    private <T extends GameEvent> void tryFireEvent(T event, Class<T> eventClass) {
         var gameEventHandler = (GameEventHandler<T, GameEventObserver<T>>) gameEventHandlers.get(eventClass);
         if (gameEventHandler != null) {
             ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
-            return true;
+            return;
         }
         System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
         System.out.println("all: " + gameEventObservers);
@@ -226,14 +224,12 @@ public class GameLoop implements Runnable {
         }
 
         if (gameEventObservers.get(eventClass).isEmpty()) {
-            return false;
+            return;
         }
 
         for (var gameEventObserver : gameEventObserverList) {
             ((GameEventObserver<T>) gameEventObserver).eventReceived(event);
         }
-
-        return true;
     }
 
     public <T extends GameEvent> void fireEvent(T event, GameLoopState whenToFire) {

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -191,6 +191,7 @@ public class GameLoop implements Runnable {
             return;
         }
         System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
+        System.out.println("all: " + gameEventObservers);
 
         List<GameEventObserver<? extends GameEvent>> gameEventObserverList = gameEventObservers.get(eventClass);
         if (gameEventObserverList == null) {

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -305,6 +305,7 @@ public class GameLoop implements Runnable {
             return;
         }
         System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
+        System.out.println("all: " + gameEventObservers);
 
         while (!gameEvents.isEmpty()) {
             GameEvent nextEvent = gameEvents.poll();

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -200,29 +200,21 @@ public class GameLoop implements Runnable {
 
     @SuppressWarnings("unchecked")
     public <T extends GameEvent> void fireEvent(T event) {
-        Set<Object> alreadyViewed = new HashSet<>();
-        Set<Object> handlerAlreadyViewed = new HashSet<>();
-
         Class<T> eventClass = (Class<T>) event.getClass();
-        tryFireEvent(event, eventClass, alreadyViewed, handlerAlreadyViewed);
+        tryFireEvent(event, eventClass);
 
 
         Class<GameEvent> classAlias = (Class<GameEvent>) classAliases.get(eventClass);
         if (classAlias != null) {
-            tryFireEvent(event, classAlias, alreadyViewed, handlerAlreadyViewed);
+            tryFireEvent(event, classAlias);
         }
-
-        alreadyViewed.clear();
-        handlerAlreadyViewed.clear();
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends GameEvent> void tryFireEvent(T event, Class<T> eventClass, Set<Object> alreadyViewedEvent, Set<Object> handlerAlreadyViewed) {
+    private <T extends GameEvent> void tryFireEvent(T event, Class<T> eventClass) {
         var gameEventHandler = (GameEventHandler<T, GameEventObserver<T>>) gameEventHandlers.get(eventClass);
         if (gameEventHandler != null) {
-            if (handlerAlreadyViewed.add(gameEventHandler)) {
-                ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
-            }
+            ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
             return;
         }
         Log.trace(GameLoop.class, "on {}, {}", eventClass, gameEventObservers.get(eventClass));
@@ -239,10 +231,7 @@ public class GameLoop implements Runnable {
         }
 
         for (var gameEventObserver : gameEventObserverList) {
-            if (alreadyViewedEvent.add(gameEventObserver)) {
-                ((GameEventObserver<T>) gameEventObserver).eventReceived(event);
-            }
-
+            ((GameEventObserver<T>) gameEventObserver).eventReceived(event);
         }
     }
 

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -1,15 +1,14 @@
 package tech.fastj.gameloop;
 
 import tech.fastj.logging.Log;
+import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.GameEventHandler;
+import tech.fastj.gameloop.event.GameEventObserver;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
-
-import tech.fastj.gameloop.event.GameEvent;
-import tech.fastj.gameloop.event.GameEventHandler;
-import tech.fastj.gameloop.event.GameEventObserver;
 
 public class GameLoop implements Runnable {
 
@@ -212,13 +211,15 @@ public class GameLoop implements Runnable {
 
     @SuppressWarnings("unchecked")
     private <T extends GameEvent> void tryFireEvent(T event, Class<T> eventClass) {
+        Log.info(GameLoop.class, "on {}, {}", eventClass, gameEventObservers.get(eventClass));
+        Log.trace(GameLoop.class, "count all: {}", gameEventObservers.size());
+
         var gameEventHandler = (GameEventHandler<T, GameEventObserver<T>>) gameEventHandlers.get(eventClass);
         if (gameEventHandler != null) {
+            Log.trace(GameLoop.class, "count all: {}", gameEventHandler);
             ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
             return;
         }
-        Log.trace(GameLoop.class, "on {}, {}", eventClass, gameEventObservers.get(eventClass));
-        Log.trace(GameLoop.class, "count all: {}", gameEventObservers.size());
 
         List<GameEventObserver<? extends GameEvent>> gameEventObserverList = gameEventObservers.get(eventClass);
         if (gameEventObserverList == null) {

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -1,6 +1,5 @@
 package tech.fastj.gameloop;
 
-import tech.fastj.logging.Log;
 import tech.fastj.gameloop.event.GameEvent;
 import tech.fastj.gameloop.event.GameEventHandler;
 import tech.fastj.gameloop.event.GameEventObserver;
@@ -211,12 +210,8 @@ public class GameLoop implements Runnable {
 
     @SuppressWarnings("unchecked")
     private <T extends GameEvent> void tryFireEvent(T event, Class<T> eventClass) {
-        Log.info(GameLoop.class, "on {}, {}", eventClass, gameEventObservers.get(eventClass));
-        Log.trace(GameLoop.class, "count all: {}", gameEventObservers.size());
-
         var gameEventHandler = (GameEventHandler<T, GameEventObserver<T>>) gameEventHandlers.get(eventClass);
         if (gameEventHandler != null) {
-            Log.trace(GameLoop.class, "count all: {}", gameEventHandler);
             ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
             return;
         }

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -1,5 +1,6 @@
 package tech.fastj.gameloop;
 
+import tech.fastj.logging.Log;
 import tech.fastj.gameloop.event.GameEvent;
 import tech.fastj.gameloop.event.GameEventHandler;
 import tech.fastj.gameloop.event.GameEventObserver;
@@ -214,8 +215,8 @@ public class GameLoop implements Runnable {
             ((GameEventHandler) gameEventHandler).handleEvent(gameEventObservers.get(eventClass), event);
             return;
         }
-        System.out.println("on " + eventClass + ", " + gameEventObservers.get(eventClass));
-        System.out.println("all: " + gameEventObservers);
+        Log.trace(GameLoop.class, "on {}, {}", eventClass, gameEventObservers.get(eventClass));
+        Log.trace(GameLoop.class, "count all: {}", gameEventObservers.size());
 
         List<GameEventObserver<? extends GameEvent>> gameEventObserverList = gameEventObservers.get(eventClass);
         if (gameEventObserverList == null) {

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -222,6 +222,10 @@ public class GameLoop implements Runnable {
         List<GameEventObserver<? extends GameEvent>> gameEventObserverList = gameEventObservers.get(eventClass);
         if (gameEventObserverList == null) {
             gameEventObservers.put(eventClass, new ArrayList<>());
+            gameEventObserverList = gameEventObservers.get(eventClass);
+        }
+
+        if (gameEventObservers.get(eventClass).isEmpty()) {
             return false;
         }
 

--- a/src/main/java/tech/fastj/gameloop/event/GameEvent.java
+++ b/src/main/java/tech/fastj/gameloop/event/GameEvent.java
@@ -1,8 +1,14 @@
 package tech.fastj.gameloop.event;
 
-public interface GameEvent {
+public class GameEvent {
 
-    boolean isConsumed();
+    private boolean isConsumed = false;
 
-    void consume();
+    public boolean isConsumed() {
+        return isConsumed;
+    }
+
+    public void consume() {
+        isConsumed = true;
+    }
 }

--- a/src/main/java/tech/fastj/gameloop/event/GameEvent.java
+++ b/src/main/java/tech/fastj/gameloop/event/GameEvent.java
@@ -1,4 +1,8 @@
 package tech.fastj.gameloop.event;
 
 public interface GameEvent {
+
+    boolean isConsumed();
+
+    void consume();
 }

--- a/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
+++ b/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
@@ -12,6 +12,8 @@ public class DisplayEvent<T extends Display> implements GameEvent {
     private final T displaySource;
     private final boolean hasWindowEvent;
 
+    private boolean isConsumed = false;
+
     public DisplayEvent(DisplayEventType eventType, WindowEvent rawEvent, T displaySource) {
         this.eventType = eventType;
         this.rawEvent = rawEvent;
@@ -40,5 +42,15 @@ public class DisplayEvent<T extends Display> implements GameEvent {
 
     public boolean hasWindowEvent() {
         return hasWindowEvent;
+    }
+
+    @Override
+    public boolean isConsumed() {
+        return isConsumed;
+    }
+
+    @Override
+    public void consume() {
+        isConsumed = true;
     }
 }

--- a/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
+++ b/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
@@ -5,14 +5,12 @@ import tech.fastj.gameloop.event.GameEvent;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
 
-public class DisplayEvent<T extends Display> implements GameEvent {
+public class DisplayEvent<T extends Display> extends GameEvent {
 
     private final DisplayEventType eventType;
     private final ComponentEvent rawEvent;
     private final T displaySource;
     private final boolean hasWindowEvent;
-
-    private boolean isConsumed = false;
 
     public DisplayEvent(DisplayEventType eventType, WindowEvent rawEvent, T displaySource) {
         this.eventType = eventType;
@@ -42,15 +40,5 @@ public class DisplayEvent<T extends Display> implements GameEvent {
 
     public boolean hasWindowEvent() {
         return hasWindowEvent;
-    }
-
-    @Override
-    public boolean isConsumed() {
-        return isConsumed;
-    }
-
-    @Override
-    public void consume() {
-        isConsumed = true;
     }
 }

--- a/src/main/java/tech/fastj/graphics/ui/elements/Button.java
+++ b/src/main/java/tech/fastj/graphics/ui/elements/Button.java
@@ -280,6 +280,7 @@ public class Button extends UIElement<MouseButtonEvent> implements MouseActionLi
     public void onMousePressed(MouseButtonEvent mouseButtonEvent) {
         if (onActionCondition.condition(mouseButtonEvent)) {
             onActionEvents.forEach(action -> action.accept(mouseButtonEvent));
+            mouseButtonEvent.consume();
         }
     }
 

--- a/src/main/java/tech/fastj/input/InputActionEvent.java
+++ b/src/main/java/tech/fastj/input/InputActionEvent.java
@@ -4,6 +4,6 @@ import tech.fastj.gameloop.event.GameEvent;
 
 import java.awt.event.InputEvent;
 
-public interface InputActionEvent extends GameEvent {
-    InputEvent getRawEvent();
+public abstract class InputActionEvent extends GameEvent {
+    public abstract InputEvent getRawEvent();
 }

--- a/src/main/java/tech/fastj/input/InputManager.java
+++ b/src/main/java/tech/fastj/input/InputManager.java
@@ -22,6 +22,8 @@ public class InputManager {
     private final List<KeyboardActionListener> keyboardActionListeners;
     private final List<MouseActionListener> mouseActionListeners;
 
+    private boolean isLoaded;
+
     public InputManager() {
         keyboardActionListeners = new ArrayList<>();
         mouseActionListeners = new ArrayList<>();
@@ -105,21 +107,30 @@ public class InputManager {
     }
 
     public void load() {
+        if (isLoaded) {
+            return;
+        }
+
         for (MouseActionListener mouseActionListener : mouseActionListeners) {
             FastJEngine.getGameLoop().addEventObserver(mouseActionListener, MouseActionEvent.class);
         }
         for (KeyboardActionListener keyboardActionListener : keyboardActionListeners) {
             FastJEngine.getGameLoop().addEventObserver(keyboardActionListener, KeyboardActionEvent.class);
         }
+        isLoaded = true;
     }
 
     public void unload() {
+        if (!isLoaded) {
+            return;
+        }
         for (MouseActionListener mouseActionListener : mouseActionListeners) {
             FastJEngine.getGameLoop().removeEventObserver(mouseActionListener, MouseActionEvent.class);
         }
         for (KeyboardActionListener keyboardActionListener : keyboardActionListeners) {
             FastJEngine.getGameLoop().removeEventObserver(keyboardActionListener, KeyboardActionEvent.class);
         }
+        isLoaded = false;
     }
 
     /** Resets the input manager. */

--- a/src/main/java/tech/fastj/input/InputManager.java
+++ b/src/main/java/tech/fastj/input/InputManager.java
@@ -8,6 +8,7 @@ import tech.fastj.input.keyboard.events.KeyboardActionEvent;
 import tech.fastj.input.mouse.MouseActionListener;
 import tech.fastj.input.mouse.events.MouseActionEvent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -17,6 +18,14 @@ import java.util.List;
  * keyboard/mouse action listeners.
  */
 public class InputManager {
+
+    private final List<KeyboardActionListener> keyboardActionListeners;
+    private final List<MouseActionListener> mouseActionListeners;
+
+    public InputManager() {
+        keyboardActionListeners = new ArrayList<>();
+        mouseActionListeners = new ArrayList<>();
+    }
 
     /**
      * Gets the list of keyboard action listeners.
@@ -48,6 +57,7 @@ public class InputManager {
      * @param listener The {@code KeyboardActionListener} to be added.
      */
     public void addKeyboardActionListener(KeyboardActionListener listener) {
+        keyboardActionListeners.add(listener);
         FastJEngine.getGameLoop().addEventObserver(listener, KeyboardActionEvent.class);
     }
 
@@ -57,6 +67,7 @@ public class InputManager {
      * @param listener The {@code KeyboardActionListener} to be removed.
      */
     public void removeKeyboardActionListener(KeyboardActionListener listener) {
+        keyboardActionListeners.remove(listener);
         FastJEngine.getGameLoop().removeEventObserver(listener, KeyboardActionEvent.class);
     }
 
@@ -79,6 +90,7 @@ public class InputManager {
      * @param listener The {@code MouseActionListener} to be added.
      */
     public void addMouseActionListener(MouseActionListener listener) {
+        mouseActionListeners.add(listener);
         FastJEngine.getGameLoop().addEventObserver(listener, MouseActionEvent.class);
     }
 
@@ -88,7 +100,26 @@ public class InputManager {
      * @param listener The {@code MouseActionListener} to be removed.
      */
     public void removeMouseActionListener(MouseActionListener listener) {
+        mouseActionListeners.remove(listener);
         FastJEngine.getGameLoop().removeEventObserver(listener, MouseActionEvent.class);
+    }
+
+    public void load() {
+        for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            FastJEngine.getGameLoop().addEventObserver(mouseActionListener, MouseActionEvent.class);
+        }
+        for (KeyboardActionListener keyboardActionListener : keyboardActionListeners) {
+            FastJEngine.getGameLoop().addEventObserver(keyboardActionListener, KeyboardActionEvent.class);
+        }
+    }
+
+    public void unload() {
+        for (MouseActionListener mouseActionListener : mouseActionListeners) {
+            FastJEngine.getGameLoop().removeEventObserver(mouseActionListener, MouseActionEvent.class);
+        }
+        for (KeyboardActionListener keyboardActionListener : keyboardActionListeners) {
+            FastJEngine.getGameLoop().removeEventObserver(keyboardActionListener, KeyboardActionEvent.class);
+        }
     }
 
     /** Resets the input manager. */

--- a/src/main/java/tech/fastj/input/keyboard/Keyboard.java
+++ b/src/main/java/tech/fastj/input/keyboard/Keyboard.java
@@ -89,6 +89,8 @@ public class Keyboard implements KeyListener {
 
         keyChecker = Executors.newSingleThreadScheduledExecutor();
         keyChecker.scheduleWithFixedDelay(Keyboard::keyCheck, 1, 1, TimeUnit.MILLISECONDS);
+        FastJEngine.getGameLoop().addClassAlias(KeyboardStateEvent.class, KeyboardActionEvent.class);
+        FastJEngine.getGameLoop().addClassAlias(KeyboardTypedEvent.class, KeyboardActionEvent.class);
 
         if (FastJEngine.isLogging(LogLevel.Debug)) {
             Log.debug(Keyboard.class, "Keyboard initialization complete.");
@@ -109,6 +111,9 @@ public class Keyboard implements KeyListener {
     /** Clears all key input from the keyboard. */
     public static void reset() {
         AllKeys.clear();
+
+        FastJEngine.getGameLoop().removeClassAlias(KeyboardStateEvent.class);
+        FastJEngine.getGameLoop().removeClassAlias(KeyboardTypedEvent.class);
     }
 
     /**

--- a/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
+++ b/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
@@ -53,20 +53,26 @@ public interface KeyboardActionListener extends GameEventObserver<KeyboardAction
     }
 
     @Override
-    default void eventReceived(KeyboardActionEvent event) {
-        switch (event.getRawEvent().getID()) {
+    default void eventReceived(KeyboardActionEvent keyboardActionEvent) {
+        if (keyboardActionEvent.isConsumed()) {
+            return;
+        }
+
+        switch (keyboardActionEvent.getRawEvent().getID()) {
             case KeyEvent.KEY_PRESSED: {
-                onKeyRecentlyPressed((KeyboardStateEvent) event);
+                onKeyRecentlyPressed((KeyboardStateEvent) keyboardActionEvent);
                 break;
             }
             case KeyEvent.KEY_RELEASED: {
-                onKeyReleased((KeyboardStateEvent) event);
+                onKeyReleased((KeyboardStateEvent) keyboardActionEvent);
                 break;
             }
             case KeyEvent.KEY_TYPED: {
-                onKeyTyped((KeyboardTypedEvent) event);
+                onKeyTyped((KeyboardTypedEvent) keyboardActionEvent);
                 break;
             }
         }
+
+        keyboardActionEvent.consume();
     }
 }

--- a/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
+++ b/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
@@ -72,7 +72,5 @@ public interface KeyboardActionListener extends GameEventObserver<KeyboardAction
                 break;
             }
         }
-
-        keyboardActionEvent.consume();
     }
 }

--- a/src/main/java/tech/fastj/input/keyboard/events/KeyboardActionEvent.java
+++ b/src/main/java/tech/fastj/input/keyboard/events/KeyboardActionEvent.java
@@ -4,9 +4,10 @@ import tech.fastj.input.InputActionEvent;
 
 import java.awt.event.KeyEvent;
 
-public interface KeyboardActionEvent extends InputActionEvent {
-    @Override
-    KeyEvent getRawEvent();
+public abstract class KeyboardActionEvent extends InputActionEvent {
 
-    String getKeyName();
+    @Override
+    public abstract KeyEvent getRawEvent();
+
+    public abstract String getKeyName();
 }

--- a/src/main/java/tech/fastj/input/keyboard/events/KeyboardStateEvent.java
+++ b/src/main/java/tech/fastj/input/keyboard/events/KeyboardStateEvent.java
@@ -6,7 +6,7 @@ import java.awt.event.KeyEvent;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class KeyboardStateEvent implements KeyboardActionEvent {
+public class KeyboardStateEvent extends KeyboardActionEvent {
 
     private static final Map<int[], Keys> KeyboardMap = new ConcurrentHashMap<>();
     private final KeyEvent keyEvent;

--- a/src/main/java/tech/fastj/input/keyboard/events/KeyboardTypedEvent.java
+++ b/src/main/java/tech/fastj/input/keyboard/events/KeyboardTypedEvent.java
@@ -2,7 +2,7 @@ package tech.fastj.input.keyboard.events;
 
 import java.awt.event.KeyEvent;
 
-public class KeyboardTypedEvent implements KeyboardActionEvent {
+public class KeyboardTypedEvent extends KeyboardActionEvent {
 
     private final KeyEvent keyEvent;
 

--- a/src/main/java/tech/fastj/input/mouse/Mouse.java
+++ b/src/main/java/tech/fastj/input/mouse/Mouse.java
@@ -167,6 +167,11 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
         mouseExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
+        FastJEngine.getGameLoop().addClassAlias(MouseWindowEvent.class, MouseActionEvent.class);
+        FastJEngine.getGameLoop().addClassAlias(MouseScrollEvent.class, MouseActionEvent.class);
+        FastJEngine.getGameLoop().addClassAlias(MouseMotionEvent.class, MouseActionEvent.class);
+        FastJEngine.getGameLoop().addClassAlias(MouseButtonEvent.class, MouseActionEvent.class);
+
         if (FastJEngine.isLogging(LogLevel.Debug)) {
             Log.debug(Mouse.class, "Mouse initialization complete.");
         }
@@ -322,6 +327,11 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
 
         MouseButtons.clear();
         mouseLocation.reset();
+
+        FastJEngine.getGameLoop().removeClassAlias(MouseWindowEvent.class);
+        FastJEngine.getGameLoop().removeClassAlias(MouseScrollEvent.class);
+        FastJEngine.getGameLoop().removeClassAlias(MouseMotionEvent.class);
+        FastJEngine.getGameLoop().removeClassAlias(MouseButtonEvent.class);
     }
 
     public static void stop() {

--- a/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
+++ b/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
@@ -95,32 +95,26 @@ public interface MouseActionListener extends GameEventObserver<MouseActionEvent>
 
         switch (mouseActionEvent.getEventType()) {
             case Press: {
-                assert mouseActionEvent instanceof MouseButtonEvent;
                 onMousePressed((MouseButtonEvent) mouseActionEvent);
                 break;
             }
             case Release: {
-                assert mouseActionEvent instanceof MouseButtonEvent;
                 onMouseReleased((MouseButtonEvent) mouseActionEvent);
                 break;
             }
             case Click: {
-                assert mouseActionEvent instanceof MouseButtonEvent;
                 onMouseClicked((MouseButtonEvent) mouseActionEvent);
                 break;
             }
             case Move: {
-                assert mouseActionEvent instanceof MouseMotionEvent;
                 onMouseMoved((MouseMotionEvent) mouseActionEvent);
                 break;
             }
             case Drag: {
-                assert mouseActionEvent instanceof MouseMotionEvent;
                 onMouseDragged((MouseMotionEvent) mouseActionEvent);
                 break;
             }
             case WheelScroll: {
-                assert mouseActionEvent instanceof MouseScrollEvent;
                 onMouseWheelScrolled((MouseScrollEvent) mouseActionEvent);
                 break;
             }

--- a/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
+++ b/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
@@ -89,6 +89,10 @@ public interface MouseActionListener extends GameEventObserver<MouseActionEvent>
 
     @Override
     default void eventReceived(MouseActionEvent mouseActionEvent) {
+        if (mouseActionEvent.isConsumed()) {
+            return;
+        }
+
         switch (mouseActionEvent.getEventType()) {
             case Press: {
                 assert mouseActionEvent instanceof MouseButtonEvent;
@@ -129,5 +133,7 @@ public interface MouseActionListener extends GameEventObserver<MouseActionEvent>
                 break;
             }
         }
+
+        mouseActionEvent.consume();
     }
 }

--- a/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
+++ b/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
@@ -133,7 +133,5 @@ public interface MouseActionListener extends GameEventObserver<MouseActionEvent>
                 break;
             }
         }
-
-        mouseActionEvent.consume();
     }
 }

--- a/src/main/java/tech/fastj/input/mouse/events/MouseActionEvent.java
+++ b/src/main/java/tech/fastj/input/mouse/events/MouseActionEvent.java
@@ -5,9 +5,9 @@ import tech.fastj.input.mouse.MouseAction;
 
 import java.awt.event.MouseEvent;
 
-public interface MouseActionEvent extends InputActionEvent {
+public abstract class MouseActionEvent extends InputActionEvent {
     @Override
-    MouseEvent getRawEvent();
+    public abstract MouseEvent getRawEvent();
 
-    MouseAction getEventType();
+    public abstract MouseAction getEventType();
 }

--- a/src/main/java/tech/fastj/input/mouse/events/MouseButtonEvent.java
+++ b/src/main/java/tech/fastj/input/mouse/events/MouseButtonEvent.java
@@ -5,7 +5,7 @@ import tech.fastj.input.mouse.MouseAction;
 import java.awt.event.MouseEvent;
 import java.util.Objects;
 
-public class MouseButtonEvent implements MouseActionEvent {
+public class MouseButtonEvent extends MouseActionEvent {
 
     private final MouseEvent mouseEvent;
     private final int button;

--- a/src/main/java/tech/fastj/input/mouse/events/MouseMotionEvent.java
+++ b/src/main/java/tech/fastj/input/mouse/events/MouseMotionEvent.java
@@ -7,7 +7,7 @@ import tech.fastj.input.mouse.MouseAction;
 import java.awt.event.MouseEvent;
 import java.util.Objects;
 
-public class MouseMotionEvent implements MouseActionEvent {
+public class MouseMotionEvent extends MouseActionEvent {
 
     private final MouseEvent mouseEvent;
     private final Pointf mouseLocation;

--- a/src/main/java/tech/fastj/input/mouse/events/MouseScrollEvent.java
+++ b/src/main/java/tech/fastj/input/mouse/events/MouseScrollEvent.java
@@ -6,7 +6,7 @@ import tech.fastj.input.mouse.MouseScrollType;
 import java.awt.event.MouseWheelEvent;
 import java.util.Objects;
 
-public class MouseScrollEvent implements MouseActionEvent {
+public class MouseScrollEvent extends MouseActionEvent {
 
     private final MouseWheelEvent mouseWheelEvent;
     private final MouseScrollType mouseScrollType;

--- a/src/main/java/tech/fastj/input/mouse/events/MouseWindowEvent.java
+++ b/src/main/java/tech/fastj/input/mouse/events/MouseWindowEvent.java
@@ -7,7 +7,7 @@ import tech.fastj.input.mouse.MouseAction;
 import java.awt.event.MouseEvent;
 import java.util.Objects;
 
-public class MouseWindowEvent implements MouseActionEvent {
+public class MouseWindowEvent extends MouseActionEvent {
 
     private final MouseEvent mouseEvent;
     private final Pointf windowInteractionPosition;

--- a/src/main/java/tech/fastj/systems/audio/Audio.java
+++ b/src/main/java/tech/fastj/systems/audio/Audio.java
@@ -3,6 +3,7 @@ package tech.fastj.systems.audio;
 import tech.fastj.systems.audio.state.PlaybackState;
 import tech.fastj.systems.tags.TaggableEntity;
 
+import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -23,7 +24,7 @@ import javax.sound.sampled.DataLine;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public abstract class Audio extends TaggableEntity implements AutoCloseable {
+public abstract class Audio extends TaggableEntity implements Closeable {
 
     protected final Path audioPath;
     protected final String id;

--- a/src/main/java/tech/fastj/systems/audio/Audio.java
+++ b/src/main/java/tech/fastj/systems/audio/Audio.java
@@ -3,7 +3,6 @@ package tech.fastj.systems.audio;
 import tech.fastj.systems.audio.state.PlaybackState;
 import tech.fastj.systems.tags.TaggableEntity;
 
-import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -24,7 +23,7 @@ import javax.sound.sampled.DataLine;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public abstract class Audio extends TaggableEntity implements Closeable {
+public abstract class Audio extends TaggableEntity {
 
     protected final Path audioPath;
     protected final String id;

--- a/src/main/java/tech/fastj/systems/audio/Audio.java
+++ b/src/main/java/tech/fastj/systems/audio/Audio.java
@@ -23,7 +23,7 @@ import javax.sound.sampled.DataLine;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public abstract class Audio extends TaggableEntity {
+public abstract class Audio extends TaggableEntity implements AutoCloseable {
 
     protected final Path audioPath;
     protected final String id;

--- a/src/main/java/tech/fastj/systems/audio/AudioEvent.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEvent.java
@@ -5,8 +5,11 @@ import tech.fastj.gameloop.event.GameEvent;
 import javax.sound.sampled.LineEvent;
 
 public class AudioEvent implements GameEvent {
+
     private final LineEvent rawEvent;
     private final Audio eventSource;
+
+    private boolean isConsumed = false;
 
     public AudioEvent(LineEvent rawEvent, Audio eventSource) {
         this.rawEvent = rawEvent;
@@ -19,6 +22,16 @@ public class AudioEvent implements GameEvent {
 
     public Audio getEventSource() {
         return eventSource;
+    }
+
+    @Override
+    public boolean isConsumed() {
+        return isConsumed;
+    }
+
+    @Override
+    public void consume() {
+        isConsumed = true;
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/AudioEvent.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEvent.java
@@ -1,5 +1,7 @@
 package tech.fastj.systems.audio;
 
+import tech.fastj.systems.audio.state.PlaybackState;
+
 import tech.fastj.gameloop.event.GameEvent;
 
 import javax.sound.sampled.LineEvent;
@@ -8,10 +10,18 @@ public class AudioEvent extends GameEvent {
 
     private final LineEvent rawEvent;
     private final Audio eventSource;
+    private final PlaybackState eventState;
 
     public AudioEvent(LineEvent rawEvent, Audio eventSource) {
         this.rawEvent = rawEvent;
         this.eventSource = eventSource;
+        this.eventState = null;
+    }
+
+    public AudioEvent(LineEvent rawEvent, Audio eventSource, PlaybackState eventState) {
+        this.rawEvent = rawEvent;
+        this.eventSource = eventSource;
+        this.eventState = eventState;
     }
 
     public LineEvent getRawEvent() {
@@ -20,6 +30,10 @@ public class AudioEvent extends GameEvent {
 
     public Audio getEventSource() {
         return eventSource;
+    }
+
+    public PlaybackState getEventState() {
+        return eventState;
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/AudioEvent.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEvent.java
@@ -4,12 +4,10 @@ import tech.fastj.gameloop.event.GameEvent;
 
 import javax.sound.sampled.LineEvent;
 
-public class AudioEvent implements GameEvent {
+public class AudioEvent extends GameEvent {
 
     private final LineEvent rawEvent;
     private final Audio eventSource;
-
-    private boolean isConsumed = false;
 
     public AudioEvent(LineEvent rawEvent, Audio eventSource) {
         this.rawEvent = rawEvent;
@@ -22,16 +20,6 @@ public class AudioEvent implements GameEvent {
 
     public Audio getEventSource() {
         return eventSource;
-    }
-
-    @Override
-    public boolean isConsumed() {
-        return isConsumed;
-    }
-
-    @Override
-    public void consume() {
-        isConsumed = true;
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
@@ -33,6 +33,7 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
     private static final Map<LineEvent.Type, BiConsumer<AudioEvent, AudioEventListener>> AudioEventProcessor = Map.of(
             LineEvent.Type.OPEN, (audioEvent, audioEventListener) -> {
                 if (audioEventListener.audioOpenAction != null) {
+                    System.out.println("open from open");
                     audioEventListener.audioOpenAction.accept(audioEvent);
                 }
             },
@@ -52,11 +53,13 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
                      * those break statements for a while now. */
                     case Paused: {
                         if (audioEventListener.audioResumeAction != null) {
+                            System.out.println("pause on previous from start");
                             audioEventListener.audioResumeAction.accept(audioEvent);
                         }
                     }
                     case Stopped: {
                         if (audioEventListener.audioStartAction != null) {
+                            System.out.println("stop on previous from start");
                             audioEventListener.audioStartAction.accept(audioEvent);
                         }
                         break;
@@ -72,11 +75,13 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
                     /* See the above comment. */
                     case Paused: {
                         if (audioEventListener.audioPauseAction != null) {
+                            System.out.println("pause on current from stop");
                             audioEventListener.audioPauseAction.accept(audioEvent);
                         }
                     }
                     case Stopped: {
                         if (audioEventListener.audioStopAction != null) {
+                            System.out.println("stop on current from stop");
                             audioEventListener.audioStopAction.accept(audioEvent);
                         }
                         break;
@@ -88,6 +93,7 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
             },
             LineEvent.Type.CLOSE, (audioEvent, audioEventListener) -> {
                 if (audioEventListener.audioCloseAction != null) {
+                    System.out.println("close from close");
                     audioEventListener.audioCloseAction.accept(audioEvent);
                 }
             }

--- a/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
@@ -226,6 +226,13 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
     @Override
     public void eventReceived(AudioEvent audioEvent) {
         AudioEventProcessor.get(audioEvent.getRawEvent().getType()).accept(audioEvent, this);
+        if (audioEvent.getRawEvent().getType() == LineEvent.Type.CLOSE && audioEvent.getEventSource().currentPlaybackState != PlaybackState.Stopped) {
+            try {
+                audio.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
@@ -83,6 +83,8 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
                         if (audioEventListener.audioStopAction != null) {
                             System.out.println("stop on current from stop");
                             audioEventListener.audioStopAction.accept(audioEvent);
+                        } else {
+                            System.out.println("no action");
                         }
                         break;
                     }
@@ -226,13 +228,6 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
     @Override
     public void eventReceived(AudioEvent audioEvent) {
         AudioEventProcessor.get(audioEvent.getRawEvent().getType()).accept(audioEvent, this);
-        if (audioEvent.getRawEvent().getType() == LineEvent.Type.CLOSE && audioEvent.getEventSource().currentPlaybackState != PlaybackState.Stopped) {
-            try {
-                audio.close();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
@@ -33,7 +33,6 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
     private static final Map<LineEvent.Type, BiConsumer<AudioEvent, AudioEventListener>> AudioEventProcessor = Map.of(
             LineEvent.Type.OPEN, (audioEvent, audioEventListener) -> {
                 if (audioEventListener.audioOpenAction != null) {
-                    System.out.println("open from open");
                     audioEventListener.audioOpenAction.accept(audioEvent);
                 }
             },
@@ -53,13 +52,11 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
                      * those break statements for a while now. */
                     case Paused: {
                         if (audioEventListener.audioResumeAction != null) {
-                            System.out.println("pause on previous from start");
                             audioEventListener.audioResumeAction.accept(audioEvent);
                         }
                     }
                     case Stopped: {
                         if (audioEventListener.audioStartAction != null) {
-                            System.out.println("stop on previous from start");
                             audioEventListener.audioStartAction.accept(audioEvent);
                         }
                         break;
@@ -75,16 +72,12 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
                     /* See the above comment. */
                     case Paused: {
                         if (audioEventListener.audioPauseAction != null) {
-                            System.out.println("pause on current from stop");
                             audioEventListener.audioPauseAction.accept(audioEvent);
                         }
                     }
                     case Stopped: {
                         if (audioEventListener.audioStopAction != null) {
-                            System.out.println("stop on current from stop");
                             audioEventListener.audioStopAction.accept(audioEvent);
-                        } else {
-                            System.out.println("no action");
                         }
                         break;
                     }
@@ -95,7 +88,6 @@ public class AudioEventListener implements GameEventObserver<AudioEvent> {
             },
             LineEvent.Type.CLOSE, (audioEvent, audioEventListener) -> {
                 if (audioEventListener.audioCloseAction != null) {
-                    System.out.println("close from close");
                     audioEventListener.audioCloseAction.accept(audioEvent);
                 }
             }

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -57,11 +57,7 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
         StreamedAudio audio = new StreamedAudio(audioPath);
         audio.getAudioEventListener().setAudioStopAction(audioEvent -> {
             System.out.println("on close");
-            try {
-                audio.close();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            audio.reset();
             System.out.println("now play it again");
             audio.play();
         });

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -55,12 +55,6 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
      */
     public static void playSound(Path audioPath) {
         StreamedAudio audio = new StreamedAudio(audioPath);
-        audio.getAudioEventListener().setAudioStopAction(audioEvent -> {
-            System.out.println("on close");
-            audio.reset();
-            System.out.println("now play it again");
-            audio.play();
-        });
         audio.play();
     }
 
@@ -71,7 +65,6 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
      */
     public static void playSound(URL audioPath) {
         StreamedAudio audio = new StreamedAudio(audioPath);
-        audio.getAudioEventListener().setAudioStopAction(audioEvent -> audio.stop());
         audio.play();
     }
 
@@ -345,24 +338,7 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
         }
 
         try {
-            SourceDataLine sourceDataLine = (SourceDataLine) AudioSystem.getLine(lineInfo);
-            sourceDataLine.addLineListener(event -> {
-                switch (event.getType().toString()) {
-                    case "Open": {
-
-                    }
-                    case "Close": {
-
-                    }
-                    case "Stop": {
-
-                    }
-                    case "": {
-
-                    }
-                }
-            });
-            return sourceDataLine;
+            return (SourceDataLine) AudioSystem.getLine(lineInfo);
         } catch (LineUnavailableException exception) {
             throw new IllegalStateException("No audio lines were available to load the data line with format " + audioFormat + ".", exception);
         }
@@ -381,7 +357,6 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
     public void handleEvent(List<GameEventObserver<AudioEvent>> gameEventObservers, AudioEvent audioEvent) {
         for (GameEventObserver<AudioEvent> gameEventObserver : gameEventObservers) {
             if (audioEvent.getEventSource().getAudioEventListener().equals(gameEventObserver)) {
-                System.out.println("equality");
                 gameEventObserver.eventReceived(audioEvent);
                 return;
             }

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -376,9 +376,11 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
     public void handleEvent(List<GameEventObserver<AudioEvent>> gameEventObservers, AudioEvent audioEvent) {
         for (GameEventObserver<AudioEvent> gameEventObserver : gameEventObservers) {
             if (audioEvent.getEventSource().getAudioEventListener().equals(gameEventObserver)) {
+                System.out.println("equality");
                 gameEventObserver.eventReceived(audioEvent);
                 return;
             }
+            System.out.println("not equality");
         }
     }
 }

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -340,7 +340,24 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
         }
 
         try {
-            return (SourceDataLine) AudioSystem.getLine(lineInfo);
+            SourceDataLine sourceDataLine = (SourceDataLine) AudioSystem.getLine(lineInfo);
+            sourceDataLine.addLineListener(event -> {
+                switch (event.getType().toString()) {
+                    case "Open": {
+
+                    }
+                    case "Close": {
+
+                    }
+                    case "Stop": {
+
+                    }
+                    case "": {
+
+                    }
+                }
+            });
+            return sourceDataLine;
         } catch (LineUnavailableException exception) {
             throw new IllegalStateException("No audio lines were available to load the data line with format " + audioFormat + ".", exception);
         }

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -55,7 +55,16 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
      */
     public static void playSound(Path audioPath) {
         StreamedAudio audio = new StreamedAudio(audioPath);
-        audio.getAudioEventListener().setAudioStopAction(audioEvent -> audio.stop());
+        audio.getAudioEventListener().setAudioStopAction(audioEvent -> {
+            System.out.println("on close");
+            try {
+                audio.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            System.out.println("now play it again");
+            audio.play();
+        });
         audio.play();
     }
 
@@ -380,7 +389,6 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
                 gameEventObserver.eventReceived(audioEvent);
                 return;
             }
-            System.out.println("not equality");
         }
     }
 }

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -70,30 +70,20 @@ public class MemoryAudio extends Audio {
     private int loopCount;
     private boolean shouldLoop;
 
-    private boolean forcedStart;
     private boolean forcedStop;
 
     private final LineListener eventHelper = event -> {
-        switch (event.getType().toString()) {
-            case "START": {
-                if (forcedStart) {
-                    return;
-                }
-
-                LineEvent startLineEvent = new LineEvent(clip, LineEvent.Type.START, clip.getLongFramePosition());
-                AudioEvent startAudioEvent = new AudioEvent(startLineEvent, this);
-                FastJEngine.getGameLoop().fireEvent(startAudioEvent);
-                break;
+        if ("STOP".equals(event.getType().toString())) {
+            if (forcedStop) {
+                System.out.println("decline on forced stop");
+                return;
             }
-            case "STOP": {
-                if (forcedStop) {
-                    return;
-                }
 
-                LineEvent stopLineEvent = new LineEvent(clip, LineEvent.Type.STOP, clip.getLongFramePosition());
-                AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, this);
-                FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
-            }
+            System.out.println("natural stop");
+
+            LineEvent stopLineEvent = new LineEvent(clip, LineEvent.Type.STOP, clip.getLongFramePosition());
+            AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, this);
+            FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
         }
     };
 
@@ -337,9 +327,7 @@ public class MemoryAudio extends Audio {
      */
     @Override
     public void play() {
-        forcedStart = true;
         MemoryAudioPlayer.playAudio(this);
-        forcedTimeout.schedule(() -> forcedStart = false, 20, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -368,9 +356,7 @@ public class MemoryAudio extends Audio {
      */
     @Override
     public void resume() {
-        forcedStart = true;
         MemoryAudioPlayer.resumeAudio(this);
-        forcedTimeout.schedule(() -> forcedStart = false, 20, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -340,7 +340,7 @@ public class MemoryAudio extends Audio {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (clip.isActive()) {
             stop();
         }

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -55,7 +55,7 @@ public class MemoryAudio extends Audio {
     public static final int LoopAtEnd = -1;
 
     private final AudioEventListener audioEventListener;
-    private Clip clip;
+    private final Clip clip;
     private final AudioInputStream audioInputStream;
 
     private float loopStart;
@@ -337,13 +337,6 @@ public class MemoryAudio extends Audio {
     @Override
     public void stop() {
         MemoryAudioPlayer.stopAudio(this);
-    }
-
-    @Override
-    public void close() {
-        if (clip.isActive()) {
-            stop();
-        }
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudio.java
@@ -134,7 +134,7 @@ public class MemoryAudio extends Audio {
     }
 
     /**
-     * Gets whether the should should be looping.
+     * Gets whether the audio should be looping.
      * <p>
      * Notes:
      * <ul>

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudioPlayer.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudioPlayer.java
@@ -67,7 +67,7 @@ public class MemoryAudioPlayer {
         audio.currentPlaybackState = PlaybackState.Paused;
 
         LineEvent lineEvent = new LineEvent(clip, LineEvent.Type.STOP, clip.getLongFramePosition());
-        AudioEvent audioEvent = new AudioEvent(lineEvent, audio);
+        AudioEvent audioEvent = new AudioEvent(lineEvent, audio, PlaybackState.Paused);
         FastJEngine.getGameLoop().fireEvent(audioEvent);
     }
 
@@ -101,7 +101,7 @@ public class MemoryAudioPlayer {
 
 
         LineEvent stopLineEvent = new LineEvent(clip, LineEvent.Type.STOP, clip.getLongFramePosition());
-        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio);
+        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio, PlaybackState.Stopped);
         FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
 
         LineEvent closeLineEvent = new LineEvent(clip, LineEvent.Type.CLOSE, clip.getLongFramePosition());
@@ -170,7 +170,7 @@ public class MemoryAudioPlayer {
         audio.currentPlaybackState = PlaybackState.Playing;
 
         LineEvent startLineEvent = new LineEvent(clip, LineEvent.Type.START, clip.getLongFramePosition());
-        AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio);
+        AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio, PlaybackState.Playing);
         FastJEngine.getGameLoop().fireEvent(startAudioEvent);
     }
 

--- a/src/main/java/tech/fastj/systems/audio/MemoryAudioPlayer.java
+++ b/src/main/java/tech/fastj/systems/audio/MemoryAudioPlayer.java
@@ -1,17 +1,20 @@
 package tech.fastj.systems.audio;
 
 import tech.fastj.engine.FastJEngine;
-import tech.fastj.logging.Log;
+
 import tech.fastj.math.Maths;
 
+import tech.fastj.logging.Log;
+
 import tech.fastj.systems.audio.state.PlaybackState;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.Clip;
 import javax.sound.sampled.LineEvent;
 import javax.sound.sampled.LineUnavailableException;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Class for playing {@link MemoryAudio memory audio}.

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -4,13 +4,6 @@ import tech.fastj.engine.FastJEngine;
 
 import tech.fastj.systems.audio.state.PlaybackState;
 
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.BooleanControl;
-import javax.sound.sampled.FloatControl;
-import javax.sound.sampled.LineEvent;
-import javax.sound.sampled.LineListener;
-import javax.sound.sampled.LineUnavailableException;
-import javax.sound.sampled.SourceDataLine;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -18,6 +11,14 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.BooleanControl;
+import javax.sound.sampled.FloatControl;
+import javax.sound.sampled.LineEvent;
+import javax.sound.sampled.LineListener;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
 
 /**
  * An audio object used for sound playback.

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -84,7 +84,6 @@ public class StreamedAudio extends Audio {
         if (resetInputStream) {
             audioInputStream = Objects.requireNonNull(AudioManager.newAudioStream(audioPath));
         }
-        System.out.println("reset data line");
         sourceDataLine = Objects.requireNonNull(AudioManager.newSourceDataLine(audioInputStream.getFormat()));
 
         try {
@@ -102,7 +101,6 @@ public class StreamedAudio extends Audio {
         muteControl = (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE);
 
         sourceDataLine.close();
-
 
         Consumer<AudioEvent> transferOpenAction = null;
         Consumer<AudioEvent> transferCloseAction = null;
@@ -230,11 +228,9 @@ public class StreamedAudio extends Audio {
 
     public void reset() {
         if (sourceDataLine.isRunning()) {
-            System.out.println("still running");
             stop();
         }
         if (!sourceDataLine.isRunning()) {
-            System.out.println("reset time");
             initializeStreamData(true);
         }
     }

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -49,30 +49,20 @@ public class StreamedAudio extends Audio {
 
     private AudioEventListener audioEventListener;
 
-    private boolean forcedStart;
     private boolean forcedStop;
 
     private final LineListener eventHelper = event -> {
-        switch (event.getType().toString()) {
-            case "START": {
-                if (forcedStart) {
-                    return;
-                }
-
-                LineEvent startLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.START, sourceDataLine.getLongFramePosition());
-                AudioEvent startAudioEvent = new AudioEvent(startLineEvent, this);
-                FastJEngine.getGameLoop().fireEvent(startAudioEvent);
-                break;
+        if ("STOP".equals(event.getType().toString())) {
+            if (forcedStop) {
+                System.out.println("decline on forced stop");
+                return;
             }
-            case "STOP": {
-                if (forcedStop) {
-                    return;
-                }
 
-                LineEvent stopLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.STOP, sourceDataLine.getLongFramePosition());
-                AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, this);
-                FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
-            }
+            System.out.println("natural stop");
+
+            LineEvent stopLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.STOP, sourceDataLine.getLongFramePosition());
+            AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, this);
+            FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
         }
     };
 
@@ -221,9 +211,7 @@ public class StreamedAudio extends Audio {
 
     @Override
     public void play() {
-        forcedStart = true;
         StreamedAudioPlayer.playAudio(this);
-        forcedTimeout.schedule(() -> forcedStart = false, 20, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -235,9 +223,7 @@ public class StreamedAudio extends Audio {
 
     @Override
     public void resume() {
-        forcedStart = true;
         StreamedAudioPlayer.resumeAudio(this);
-        forcedTimeout.schedule(() -> forcedStart = false, 20, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -127,7 +127,6 @@ public class StreamedAudio extends Audio {
         muteControl = (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE);
 
         sourceDataLine.close();
-        StreamedAudioPlayer.streamAudio(this);
 
         audioEventListener = new AudioEventListener(this);
         currentPlaybackState = PlaybackState.Stopped;

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudio.java
@@ -8,8 +8,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
 import javax.sound.sampled.AudioInputStream;
@@ -47,14 +45,6 @@ public class StreamedAudio extends Audio {
     private BooleanControl muteControl;
 
     private AudioEventListener audioEventListener;
-    private boolean forceClosed;
-
-    private static ScheduledExecutorService forcedTimeout = Executors.newScheduledThreadPool(2);
-
-    public static void reset() {
-        forcedTimeout.shutdownNow();
-        forcedTimeout = Executors.newScheduledThreadPool(2);
-    }
 
     /**
      * Constructs the {@code StreamedAudio} object with the given path.
@@ -235,16 +225,13 @@ public class StreamedAudio extends Audio {
 
     @Override
     public void stop() {
-        forceClosed = true;
         StreamedAudioPlayer.stopAudio(this);
     }
 
-    @Override
-    public void close() {
-        if (sourceDataLine.isRunning() && !forceClosed) {
+    public void reset() {
+        if (sourceDataLine.isRunning()) {
             System.out.println("still running");
             stop();
-            forceClosed = false;
         }
         if (!sourceDataLine.isRunning()) {
             System.out.println("reset time");

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
@@ -49,6 +49,7 @@ public class StreamedAudioPlayer {
                     }
                     sourceDataLine.write(soundSamples, 0, sourceLength);
                 }
+                audioInputStream.reset();
             } catch (IOException exception) {
                 throw new IllegalStateException("Input stream read error for audio file \"" + audio.getAudioPath().toAbsolutePath() + "\"", exception);
             } catch (InterruptedException exception) {
@@ -73,6 +74,8 @@ public class StreamedAudioPlayer {
             Log.warn(StreamedAudioPlayer.class, "Tried to play audio file \"{}\", but it was already open (and likely being used elsewhere.)", audio.getAudioPath().toString());
             return;
         }
+
+        streamAudio(audio);
 
         try {
             sourceDataLine.open(audioInputStream.getFormat());

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
@@ -43,13 +43,17 @@ public class StreamedAudioPlayer {
             int sourceLength;
             byte[] soundSamples = new byte[BufferSize];
             try {
+                System.out.println("start reading");
                 while ((sourceLength = audioInputStream.read(soundSamples, 0, BufferSize)) != -1) {
+                    System.out.println("get " + sourceLength);
                     while (audio.currentPlaybackState != PlaybackState.Playing) {
                         TimeUnit.MILLISECONDS.sleep(100);
                     }
+                    System.out.println(sourceDataLine.available() + " available");
                     sourceDataLine.write(soundSamples, 0, sourceLength);
+                    System.out.println("written");
                 }
-                audioInputStream.reset();
+                System.out.println("done");
             } catch (IOException exception) {
                 throw new IllegalStateException("Input stream read error for audio file \"" + audio.getAudioPath().toAbsolutePath() + "\"", exception);
             } catch (InterruptedException exception) {

--- a/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
+++ b/src/main/java/tech/fastj/systems/audio/StreamedAudioPlayer.java
@@ -93,7 +93,7 @@ public class StreamedAudioPlayer {
             audio.currentPlaybackState = PlaybackState.Playing;
 
             LineEvent startLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.START, sourceDataLine.getLongFramePosition());
-            AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio);
+            AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio, PlaybackState.Playing);
             FastJEngine.getGameLoop().fireEvent(startAudioEvent);
         } catch (LineUnavailableException exception) {
             throw new IllegalStateException(
@@ -118,7 +118,7 @@ public class StreamedAudioPlayer {
         audio.currentPlaybackState = PlaybackState.Paused;
 
         LineEvent stopLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.STOP, sourceDataLine.getLongFramePosition());
-        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio);
+        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio, PlaybackState.Paused);
         FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
     }
 
@@ -137,7 +137,7 @@ public class StreamedAudioPlayer {
         audio.currentPlaybackState = PlaybackState.Playing;
 
         LineEvent startLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.START, sourceDataLine.getLongFramePosition());
-        AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio);
+        AudioEvent startAudioEvent = new AudioEvent(startLineEvent, audio, PlaybackState.Playing);
         FastJEngine.getGameLoop().fireEvent(startAudioEvent);
     }
 
@@ -159,7 +159,7 @@ public class StreamedAudioPlayer {
         System.out.println("fire?");
 
         LineEvent stopLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.STOP, sourceDataLine.getLongFramePosition());
-        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio);
+        AudioEvent stopAudioEvent = new AudioEvent(stopLineEvent, audio, PlaybackState.Stopped);
         FastJEngine.getGameLoop().fireEvent(stopAudioEvent);
 
         LineEvent closeLineEvent = new LineEvent(sourceDataLine, LineEvent.Type.CLOSE, sourceDataLine.getLongFramePosition());

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -125,6 +125,16 @@ public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
         return drawableManager.getDrawablesList();
     }
 
+    void generalLoad(FastJCanvas canvas) {
+        inputManager.load();
+        load(canvas);
+    }
+
+    void generalUnload(FastJCanvas canvas) {
+        inputManager.unload();
+        unload(canvas);
+    }
+
     /* Reset */
 
     /** Removes all elements from the scene. */

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -77,7 +77,7 @@ public abstract class SceneManager implements LogicManager {
     public void reset() {
         for (Scene scene : scenes.values()) {
             if (scene.isInitialized()) {
-                scene.unload(FastJEngine.getCanvas());
+                scene.generalUnload(FastJEngine.getCanvas());
             }
             scene.reset();
         }
@@ -99,8 +99,8 @@ public abstract class SceneManager implements LogicManager {
     /**
      * Sets the current scene to the scene specified.
      * <p>
-     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
-     * nextScene)} method.
+     * Instead of using this method to switch scenes, it is preferred that you use the
+     * {@code switchScene(String nextScene)} method.
      *
      * @param scene The scene which the current scene will be set to.
      */
@@ -111,8 +111,8 @@ public abstract class SceneManager implements LogicManager {
     /**
      * Sets the current scene to the scene with the name specified.
      * <p>
-     * Instead of using this method to switch scenes, it is preferred that you use the {@code switchScene(String
-     * nextScene)} method.
+     * Instead of using this method to switch scenes, it is preferred that you use the
+     * {@code switchScene(String nextScene)} method.
      *
      * @param sceneName The name of the scene which the current scene will be set to.
      */
@@ -210,12 +210,23 @@ public abstract class SceneManager implements LogicManager {
     /**
      * Switches to the scene specified, loading that scene if necessary.
      * <p>
-     * This is the preferred method of switching from one scene to another. However, it does not unload the last scene.
-     * That has to be done by the user.
+     * This is the preferred method of switching from one scene to another. It will also unload the current scene.
      *
      * @param nextSceneName The name of the next Scene to be loaded.
      */
     public void switchScenes(String nextSceneName) {
+        switchScenes(nextSceneName, true);
+    }
+
+    /**
+     * Switches to the scene specified, loading that scene if necessary.
+     * <p>
+     * This is the preferred method of switching from one scene to another.
+     *
+     * @param nextSceneName      The name of the next Scene to be loaded.
+     * @param unloadCurrentScene Whether to unload the current scene.
+     */
+    public void switchScenes(String nextSceneName, boolean unloadCurrentScene) {
         if (!scenes.containsKey(nextSceneName)) {
             FastJEngine.error(
                     CrashMessages.SceneError.errorMessage,
@@ -224,12 +235,18 @@ public abstract class SceneManager implements LogicManager {
         }
 
         switchingScenes = true;
-
         FastJCanvas canvas = FastJEngine.getCanvas();
+
+        if (unloadCurrentScene) {
+            currentScene.generalUnload(canvas);
+        } else {
+            currentScene.inputManager.unload();
+        }
+
         Scene nextScene = scenes.get(nextSceneName);
 
         if (!nextScene.isInitialized()) {
-            nextScene.load(canvas);
+            nextScene.generalLoad(canvas);
             nextScene.initBehaviorListeners();
             nextScene.setInitialized(true);
         }
@@ -246,7 +263,7 @@ public abstract class SceneManager implements LogicManager {
 
         if (!currentScene.isInitialized()) {
             FastJCanvas canvas = FastJEngine.getCanvas();
-            currentScene.load(canvas);
+            currentScene.generalLoad(canvas);
             canvas.setBackgroundToCameraPos(currentScene.getCamera());
         }
 

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -244,6 +244,7 @@ public abstract class SceneManager implements LogicManager {
         }
 
         Scene nextScene = scenes.get(nextSceneName);
+        nextScene.inputManager.load();
 
         if (!nextScene.isInitialized()) {
             nextScene.generalLoad(canvas);

--- a/src/test/java/unittest/mock/gameloop/event/MockEvent.java
+++ b/src/test/java/unittest/mock/gameloop/event/MockEvent.java
@@ -2,17 +2,5 @@ package unittest.mock.gameloop.event;
 
 import tech.fastj.gameloop.event.GameEvent;
 
-public class MockEvent implements GameEvent {
-
-    private boolean isConsumed = false;
-
-    @Override
-    public boolean isConsumed() {
-        return isConsumed;
-    }
-
-    @Override
-    public void consume() {
-        isConsumed = true;
-    }
+public class MockEvent extends GameEvent {
 }

--- a/src/test/java/unittest/mock/gameloop/event/MockEvent.java
+++ b/src/test/java/unittest/mock/gameloop/event/MockEvent.java
@@ -3,4 +3,16 @@ package unittest.mock.gameloop.event;
 import tech.fastj.gameloop.event.GameEvent;
 
 public class MockEvent implements GameEvent {
+
+    private boolean isConsumed = false;
+
+    @Override
+    public boolean isConsumed() {
+        return isConsumed;
+    }
+
+    @Override
+    public void consume() {
+        isConsumed = true;
+    }
 }

--- a/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
@@ -183,6 +183,11 @@ class AudioManagerTests {
     @Test
     void checkPlaySound_withPath() {
         assertDoesNotThrow(() -> AudioManager.playSound(TestAudioPath));
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/AudioManagerTests.java
@@ -183,11 +183,6 @@ class AudioManagerTests {
     @Test
     void checkPlaySound_withPath() {
         assertDoesNotThrow(() -> AudioManager.playSound(TestAudioPath));
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Test

--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -1,14 +1,11 @@
 package unittest.testcases.systems.audio;
 
 import tech.fastj.engine.FastJEngine;
-
 import tech.fastj.math.Maths;
 
 import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.MemoryAudio;
 import tech.fastj.systems.audio.state.PlaybackState;
-
-import unittest.EnvironmentHelper;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -18,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import unittest.EnvironmentHelper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,6 +171,27 @@ class MemoryAudioTests {
 
         assertEquals(expectedLoopCount, audio.getLoopCount(), "The audio loop count should be set.");
         assertEquals(expectedShouldLoop, audio.shouldLoop(), "Setting the loop to \"Audio.ContinuousLoop\" then changing the \"shouldLoop\" variable to false should cause the audio to not need to loop.");
+    }
+
+    @Test
+    void checkSetPlaybackPosition() throws InterruptedException {
+        MemoryAudio audio = AudioManager.loadMemoryAudio(TestAudioPath);
+        long expectedPlaybackPosition = Maths.randomInteger(1, 5) * 100L;
+
+        audio.setPlaybackPosition(expectedPlaybackPosition);
+        assertEquals(expectedPlaybackPosition, audio.getPlaybackPosition(), "The audio playback position should be set.");
+
+        audio.getAudioEventListener().setAudioStartAction(audioEvent -> {
+            audio.stop();
+            assertEquals(
+                    0L,
+                    audio.getPlaybackPosition(),
+                    "After the audio playback is stopped, the playback position should be at the beginning."
+            );
+        });
+
+        audio.play();
+        TimeUnit.SECONDS.sleep(2);
     }
 
     @Test

--- a/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
+++ b/src/test/java/unittest/testcases/systems/audio/MemoryAudioTests.java
@@ -1,11 +1,14 @@
 package unittest.testcases.systems.audio;
 
 import tech.fastj.engine.FastJEngine;
+
 import tech.fastj.math.Maths;
 
 import tech.fastj.systems.audio.AudioManager;
 import tech.fastj.systems.audio.MemoryAudio;
 import tech.fastj.systems.audio.state.PlaybackState;
+
+import unittest.EnvironmentHelper;
 
 import java.net.URL;
 import java.nio.file.Path;
@@ -15,7 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import unittest.EnvironmentHelper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
# Game Loop Bug Fixes, Event Pipeline Bug Fixes, Audio Engine Bug Fixes
Resolves #165
Resolves #168

## Additions
- `GameEvent` now has `isConsumed` and `consume` methods to improve event usability.
- `AudioEvent` can now hold an instance of `PlaybackState` to indicate what playback state was referenced when the event was created.
- input manager now holds state in order to keep track of when input listeners should be added and removed from the game loop


## Bug Fixes
- (#165) fix issue where `StreamedAudio` would not send events after stopping playing
- fixed issue where any type of `GameEvent` listeners could not listen for any of its subclasses, using new gameloop class aliasing
- (#168) fixed issue where `MemoryAudio` playback position would not work if the underlying `Clip` was not open

## Breaking Changes
- `SceneManager#switchScenes` now also requires a boolean parameter, stating whether to unload the current scene.
    - an overload is provided for this without the boolean parameter, but it defaults to `true`.
- `GameEvent` is now a class, in order to store the `isConsumed` variable.
    - all extending interfaces have been changed to (sometimes abstract) classes as a result.
