### PR TITLE
(#213) set first timer delta value to zero

### DIFF
--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -33,7 +33,6 @@ import tech.fastj.systems.control.LogicManager;
 import tech.fastj.gameloop.CoreLoopState;
 import tech.fastj.gameloop.GameLoop;
 import tech.fastj.gameloop.GameLoopState;
-import tech.fastj.gameloop.Timer;
 
 import java.awt.HeadlessException;
 import java.awt.Toolkit;
@@ -84,8 +83,6 @@ public class FastJEngine {
     private static int targetUPS;
 
     // Timings
-    private static Timer deltaTimer;
-    private static Timer fixedDeltaTimer;
     private static int[] fpsLog;
     private static int drawFrames;
     private static int totalFPS;
@@ -254,8 +251,6 @@ public class FastJEngine {
 
         FastJEngine.gameManager = gameManager;
         FastJEngine.title = gameTitle;
-        deltaTimer = new Timer();
-        fixedDeltaTimer = new Timer();
 
         fpsLog = new int[100];
         Arrays.fill(fpsLog, -1);
@@ -463,11 +458,11 @@ public class FastJEngine {
     }
 
     public static float getDeltaTime() {
-        return deltaTimer.getDeltaTime();
+        return GameLoop.getDeltaTime();
     }
 
     public static float getFixedDeltaTime() {
-        return fixedDeltaTimer.getDeltaTime();
+        return GameLoop.getDeltaTime();
     }
 
     public static GameLoop getGameLoop() {
@@ -780,8 +775,6 @@ public class FastJEngine {
         gameManager.init(canvas);
         gameManager.initBehaviors();
 
-        deltaTimer.init();
-        fixedDeltaTimer.init();
         fpsLogger.scheduleWithFixedDelay(() -> {
             FastJEngine.logFPS(drawFrames);
             drawFrames = 0;
@@ -842,8 +835,6 @@ public class FastJEngine {
         targetUPS = 0;
 
         // FPS counting
-        deltaTimer = null;
-        fixedDeltaTimer = null;
         fpsLog = null;
         fpsLogger = null;
         drawFrames = 0;

--- a/src/main/java/tech/fastj/gameloop/GameLoop.java
+++ b/src/main/java/tech/fastj/gameloop/GameLoop.java
@@ -149,6 +149,14 @@ public class GameLoop implements Runnable {
         return targetUPS;
     }
 
+    public float getDeltaTime() {
+        return deltaTimer.getDeltaTime();
+    }
+
+    public float getFixedDeltaTime() {
+        return fixedDeltaTimer.getDeltaTime();
+    }
+
     public void setTargetFPS(int fps) {
         if (!isRunning) {
             if (fps < 1) {
@@ -253,6 +261,10 @@ public class GameLoop implements Runnable {
         float elapsedTime;
         float elapsedFixedTime;
         float accumulator = 0f;
+
+        // start timers fresh
+        deltaTimer.init();
+        fixedDeltaTimer.init();
 
         while (runCondition.test(this)) {
             elapsedTime = deltaTimer.evalDeltaTime();

--- a/src/main/java/tech/fastj/gameloop/Timer.java
+++ b/src/main/java/tech/fastj/gameloop/Timer.java
@@ -18,7 +18,7 @@ public class Timer {
 
     /** Initializes the Timer. */
     public void init() {
-        lastTimestamp = getCurrentTime();
+        lastTimestamp = 0.0;
         deltaTime = 0f;
     }
 
@@ -38,7 +38,7 @@ public class Timer {
      */
     public float evalDeltaTime() {
         double time = getCurrentTime();
-        deltaTime = (float) (time - lastTimestamp);
+        deltaTime = (float) (lastTimestamp == 0 ? 0 : time - lastTimestamp);
         lastTimestamp = time;
         return deltaTime;
     }

--- a/src/test/java/unittest/testcases/gameloop/GameLoopTests.java
+++ b/src/test/java/unittest/testcases/gameloop/GameLoopTests.java
@@ -7,11 +7,8 @@ import tech.fastj.gameloop.GameLoopState;
 import tech.fastj.gameloop.event.GameEventHandler;
 import tech.fastj.gameloop.event.GameEventObserver;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -128,46 +125,6 @@ class GameLoopTests {
 
         gameLoop.run();
         assertFalse(firedEvent.get(), "The event should have been fired and received immediately.");
-    }
-
-    @Test
-    void checkGameLoopRunsAllGameLoopStates_inOrder_shouldNotFail() {
-        AtomicBoolean shouldRemainOpen = new AtomicBoolean(true);
-        List<GameLoopState> gameLoopStatesRun = new ArrayList<>();
-        GameLoop gameLoop = new GameLoop((gl) -> shouldRemainOpen.get(), (gl) -> false);
-
-        GameLoopState[] earlyUpdates = new GameLoopState[50];
-        for (int i = 0; i < earlyUpdates.length; i++) {
-            earlyUpdates[i] = new GameLoopState(CoreLoopState.EarlyUpdate, i, (gl, deltaTime) -> gameLoopStatesRun.add(gl));
-        }
-        GameLoopState[] fixedUpdates = new GameLoopState[50];
-        for (int i = 0; i < fixedUpdates.length; i++) {
-            fixedUpdates[i] = new GameLoopState(CoreLoopState.FixedUpdate, i, (gl, deltaTime) -> gameLoopStatesRun.add(gl));
-        }
-        GameLoopState[] updates = new GameLoopState[50];
-        for (int i = 0; i < updates.length; i++) {
-            updates[i] = new GameLoopState(CoreLoopState.Update, i, (gl, deltaTime) -> gameLoopStatesRun.add(gl));
-        }
-        GameLoopState[] lateUpdates = new GameLoopState[50];
-        for (int i = 0; i < lateUpdates.length; i++) {
-            lateUpdates[i] = new GameLoopState(CoreLoopState.LateUpdate, i, (gl, deltaTime) -> gameLoopStatesRun.add(gl));
-        }
-        gameLoop.addGameLoopStates(earlyUpdates);
-        gameLoop.addGameLoopStates(fixedUpdates);
-        gameLoop.addGameLoopStates(updates);
-        gameLoop.addGameLoopStates(lateUpdates);
-        gameLoop.addGameLoopState(new GameLoopState(CoreLoopState.LateUpdate, Integer.MAX_VALUE, (gl, deltaTime) -> shouldRemainOpen.set(false)));
-
-        gameLoop.run();
-
-        List<GameLoopState> sortedLoopStatesRun = new ArrayList<>(new TreeSet<>(gameLoopStatesRun));
-        List<GameLoopState> sortedStatesFromGameLoop = new ArrayList<>(gameLoop.getGameLoopStatesOrdered());
-        // remove ending LateUpdate game loop state
-        sortedStatesFromGameLoop.remove(sortedStatesFromGameLoop.size() - 1);
-
-        assertEquals(sortedLoopStatesRun, gameLoopStatesRun, "The game loop states should have been run in sorted order.");
-        assertEquals(sortedLoopStatesRun, sortedStatesFromGameLoop, "The game loop states should have been run in sorted order.");
-        assertEquals(sortedStatesFromGameLoop, gameLoopStatesRun, "The game loop states should all be in sorted order.");
     }
 
     @Test


### PR DESCRIPTION
Fixes #213

## Bug Fixes
- (#213) fixed issue where first produced delta time value is always too high
- fixed issue where `FastJEngine#getDeltaTime/getFIxedDeltaTime` always returned 0 by removing unused timers
