### PR TITLE
The rest of 1.7.0

### DIFF
--- a/examples/java/tech/fastj/examples/behaviors/Main.java
+++ b/examples/java/tech/fastj/examples/behaviors/Main.java
@@ -44,7 +44,7 @@ public class Main extends SimpleManager {
          * gameObject.addBehavior(Behavior, SimpleManager/Scene) -- the SimpleManager/Scene is the
          * manager the behavior is in. */
         box.addBehavior(movementBehavior, this);
-        drawableManager.addGameObject(box);
+        drawableManager().addGameObject(box);
 
 
         /* Pre-defined Behaviors */
@@ -66,7 +66,7 @@ public class Main extends SimpleManager {
                 .build();
 
         premadeBehaviorsBox.addBehavior(Behavior.simpleRotation(3f), this);
-        drawableManager.addGameObject(premadeBehaviorsBox);
+        drawableManager().addGameObject(premadeBehaviorsBox);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/bullethell/scenes/GameScene.java
+++ b/examples/java/tech/fastj/examples/bullethell/scenes/GameScene.java
@@ -58,15 +58,15 @@ public class GameScene extends Scene {
 
 
         // add game objects to the screen in order!
-        drawableManager.addGameObject(player);
-        drawableManager.addGameObject(playerHealthBar);
-        drawableManager.addGameObject(playerMetadata);
+        drawableManager().addGameObject(player);
+        drawableManager().addGameObject(playerHealthBar);
+        drawableManager().addGameObject(playerMetadata);
 
 
         enemies = new ConcurrentHashMap<>();
         newWave();
 
-        inputManager.addKeyboardActionListener(new KeyboardActionListener() {
+        inputManager().addKeyboardActionListener(new KeyboardActionListener() {
             @Override
             public void onKeyRecentlyPressed(KeyboardStateEvent keyboardStateEvent) {
                 switch (keyboardStateEvent.getKey()) {
@@ -160,7 +160,7 @@ public class GameScene extends Scene {
         Model2D enemy = Model2D.fromPolygons(ModelUtil.loadModel(Path.of(FilePaths.PathToResources + "enemy.psdf")));
         enemy.addLateBehavior(new EnemyMovement(this), this);
         enemy.setTranslation(randomPosition);
-        drawableManager.addGameObject(enemy);
+        drawableManager().addGameObject(enemy);
         return enemy;
     }
 }

--- a/examples/java/tech/fastj/examples/bullethell/scenes/GameScene.java
+++ b/examples/java/tech/fastj/examples/bullethell/scenes/GameScene.java
@@ -32,10 +32,6 @@ import tech.fastj.examples.bullethell.util.Tags;
 
 public class GameScene extends Scene {
 
-    private Model2D player;
-    private Text2D playerMetadata;
-    private Polygon2D playerHealthBar;
-
     private Map<String, Model2D> enemies;
     private int enemyCount = 0;
     private int wave = 0;
@@ -46,16 +42,16 @@ public class GameScene extends Scene {
 
     @Override
     public void load(FastJCanvas canvas) {
-        playerMetadata = createPlayerMetaData();
-        playerHealthBar = createPlayerHealthBar();
-        PlayerHealthBar playerHealthBarScript = new PlayerHealthBar(playerMetadata, this);
+        Text2D playerMetadata = createPlayerMetaData();
+        Polygon2D playerHealthBar = createPlayerHealthBar();
+        PlayerHealthBar playerHealthBarScript = new PlayerHealthBar(playerMetadata);
         playerHealthBar.addBehavior(playerHealthBarScript, this)
                 .<GameObject>addTag(Tags.PlayerHealthBar);
 
 
         PlayerController playerControllerScript = new PlayerController(3f, 3f);
         PlayerCannon playerCannonScript = new PlayerCannon(this);
-        player = createPlayer();
+        Model2D player = createPlayer();
         player.addBehavior(playerControllerScript, this)
                 .addBehavior(playerCannonScript, this)
                 .<GameObject>addTag(Tags.Player);
@@ -93,26 +89,6 @@ public class GameScene extends Scene {
 
     @Override
     public void unload(FastJCanvas canvas) {
-        if (player != null) {
-            player.destroy(this);
-            player = null;
-        }
-
-        if (playerMetadata != null) {
-            playerMetadata.destroy(this);
-            playerMetadata = null;
-        }
-
-        if (playerHealthBar != null) {
-            playerHealthBar.destroy(this);
-            playerHealthBar = null;
-        }
-
-        if (enemies != null) {
-            enemies.forEach((id, enemy) -> enemy.destroy(this));
-            enemies.clear();
-        }
-
         enemyCount = 0;
     }
 

--- a/examples/java/tech/fastj/examples/bullethell/scenes/LoseScene.java
+++ b/examples/java/tech/fastj/examples/bullethell/scenes/LoseScene.java
@@ -16,9 +16,6 @@ import tech.fastj.examples.bullethell.util.SceneNames;
 
 public class LoseScene extends Scene {
 
-    private Text2D loseText;
-    private Text2D deathInfo;
-
     public LoseScene() {
         super(SceneNames.LoseSceneName);
     }
@@ -28,12 +25,12 @@ public class LoseScene extends Scene {
         GameScene gameScene = FastJEngine.<SceneManager>getLogicManager().getScene(SceneNames.GameSceneName);
         int waveNumber = gameScene.getWaveNumber();
 
-        loseText = Text2D.create("You Lost...")
+        Text2D loseText = Text2D.create("You Lost...")
                 .withFill(Color.red)
                 .withFont(new Font("Consolas", Font.PLAIN, 96))
                 .withTransform(new Pointf(300f, 375f), Transform2D.DefaultRotation, Transform2D.DefaultScale)
                 .build();
-        deathInfo = Text2D.create("You died on wave: " + waveNumber)
+        Text2D deathInfo = Text2D.create("You died on wave: " + waveNumber)
                 .withFont(new Font("Consolas", Font.PLAIN, 16))
                 .withTransform(new Pointf(500f, 400f), Transform2D.DefaultRotation, Transform2D.DefaultScale)
                 .build();
@@ -44,8 +41,6 @@ public class LoseScene extends Scene {
 
     @Override
     public void unload(FastJCanvas canvas) {
-        loseText.destroy(this);
-        deathInfo.destroy(this);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/bullethell/scenes/LoseScene.java
+++ b/examples/java/tech/fastj/examples/bullethell/scenes/LoseScene.java
@@ -35,8 +35,8 @@ public class LoseScene extends Scene {
                 .withTransform(new Pointf(500f, 400f), Transform2D.DefaultRotation, Transform2D.DefaultScale)
                 .build();
 
-        drawableManager.addGameObject(loseText);
-        drawableManager.addGameObject(deathInfo);
+        drawableManager().addGameObject(loseText);
+        drawableManager().addGameObject(deathInfo);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/bullethell/scripts/BulletMovement.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/BulletMovement.java
@@ -7,6 +7,7 @@ import tech.fastj.graphics.game.GameObject;
 import tech.fastj.systems.behaviors.Behavior;
 
 import tech.fastj.examples.bullethell.scenes.GameScene;
+import tech.fastj.gameloop.CoreLoopState;
 
 public class BulletMovement implements Behavior {
 
@@ -53,10 +54,10 @@ public class BulletMovement implements Behavior {
     }
 
     public void bulletDied(GameObject obj) {
-        FastJEngine.runAfterUpdate(() -> {
+        FastJEngine.runLater(() -> {
             FastJEngine.log("death! of bullet {}f{}", travelAngle, travelVector);
             obj.destroy(gameScene);
             playerCannonScript.bulletDied();
-        });
+        }, CoreLoopState.FixedUpdate);
     }
 }

--- a/examples/java/tech/fastj/examples/bullethell/scripts/EnemyMovement.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/EnemyMovement.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import tech.fastj.examples.bullethell.scenes.GameScene;
 import tech.fastj.examples.bullethell.util.Tags;
+import tech.fastj.gameloop.CoreLoopState;
 
 public class EnemyMovement implements Behavior {
 
@@ -58,7 +59,7 @@ public class EnemyMovement implements Behavior {
     }
 
     private void enemyDied(GameObject enemy) {
-        FastJEngine.runAfterUpdate(() -> gameScene.enemyDied((Model2D) enemy));
+        FastJEngine.runLater(() -> gameScene.enemyDied((Model2D) enemy), CoreLoopState.FixedUpdate);
     }
 
     private void moveToPlayer(GameObject obj) {

--- a/examples/java/tech/fastj/examples/bullethell/scripts/PlayerCannon.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/PlayerCannon.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 import tech.fastj.examples.bullethell.scenes.GameScene;
 import tech.fastj.examples.bullethell.util.Tags;
+import tech.fastj.gameloop.CoreLoopState;
 
 public class PlayerCannon implements Behavior {
 
@@ -37,7 +38,7 @@ public class PlayerCannon implements Behavior {
     @Override
     public void fixedUpdate(GameObject obj) {
         if (Keyboard.isKeyRecentlyPressed(Keys.Space) && bulletCount < MaxBulletCount) {
-            FastJEngine.runAfterUpdate(() -> createBullet(obj));
+            FastJEngine.runLater(() -> createBullet(obj), CoreLoopState.FixedUpdate);
         }
     }
 

--- a/examples/java/tech/fastj/examples/bullethell/scripts/PlayerCannon.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/PlayerCannon.java
@@ -61,7 +61,7 @@ public class PlayerCannon implements Behavior {
                 .addLateBehavior(bulletMovementScript, gameScene)
                 .<GameObject>addTag(Tags.Bullet);
 
-        gameScene.drawableManager.addGameObject(bullet);
+        gameScene.drawableManager().addGameObject(bullet);
         bulletCount++;
     }
 

--- a/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import tech.fastj.examples.bullethell.scenes.GameScene;
 import tech.fastj.examples.bullethell.util.SceneNames;
+import tech.fastj.gameloop.CoreLoopState;
 
 public class PlayerHealthBar implements Behavior {
 
@@ -73,10 +74,10 @@ public class PlayerHealthBar implements Behavior {
             damageCooldown.schedule(() -> canTakeDamage = true, 1, TimeUnit.SECONDS);
 
             if (health == 0) {
-                FastJEngine.runAfterUpdate(() -> {
+                FastJEngine.runLater(() -> {
                     SceneManager sceneManager = FastJEngine.getLogicManager();
                     sceneManager.switchScenes(SceneNames.LoseSceneName);
-                });
+                }, CoreLoopState.FixedUpdate);
             }
         }
     }

--- a/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
+++ b/examples/java/tech/fastj/examples/bullethell/scripts/PlayerHealthBar.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import tech.fastj.examples.bullethell.scenes.GameScene;
 import tech.fastj.examples.bullethell.util.SceneNames;
 import tech.fastj.gameloop.CoreLoopState;
 
@@ -27,13 +26,11 @@ public class PlayerHealthBar implements Behavior {
     private boolean takenDamage;
     private boolean canTakeDamage;
 
-    private final GameScene gameScene;
     private final ScheduledExecutorService damageCooldown = Executors.newSingleThreadScheduledExecutor();
     private final Text2D playerMetadata;
 
-    public PlayerHealthBar(Text2D playerMetadata, GameScene gameScene) {
+    public PlayerHealthBar(Text2D playerMetadata) {
         this.playerMetadata = Objects.requireNonNull(playerMetadata);
-        this.gameScene = gameScene;
     }
 
     @Override
@@ -63,7 +60,7 @@ public class PlayerHealthBar implements Behavior {
 
     @Override
     public void destroy() {
-        damageCooldown.shutdownNow();
+        damageCooldown.shutdown();
     }
 
     void takeDamage() {
@@ -77,7 +74,7 @@ public class PlayerHealthBar implements Behavior {
                 FastJEngine.runLater(() -> {
                     SceneManager sceneManager = FastJEngine.getLogicManager();
                     sceneManager.switchScenes(SceneNames.LoseSceneName);
-                }, CoreLoopState.FixedUpdate);
+                }, CoreLoopState.LateUpdate);
             }
         }
     }

--- a/examples/java/tech/fastj/examples/engineconfig/Main.java
+++ b/examples/java/tech/fastj/examples/engineconfig/Main.java
@@ -19,7 +19,7 @@ public class Main extends SimpleManager {
          * The code is not the primary focus of the example -- this is just to give a visual. */
         Pointf[] squareMesh = DrawUtil.createBox(50f, 50f, 100f);
         Polygon2D square = Polygon2D.fromPoints(squareMesh);
-        drawableManager.addGameObject(square);
+        drawableManager().addGameObject(square);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/keyboard/Main.java
+++ b/examples/java/tech/fastj/examples/keyboard/Main.java
@@ -42,7 +42,7 @@ public class Main extends SimpleManager {
          * To demonstrate each method, I've chosen to log whenever any of the methods is called. Run the program to see
          * this in action. */
 
-        inputManager.addKeyboardActionListener(new KeyboardActionListener() {
+        inputManager().addKeyboardActionListener(new KeyboardActionListener() {
             @Override
             public void onKeyDown(Set<Keys> keysDown) {
                 FastJEngine.log("Key(s) held down: {}", keysDown);

--- a/examples/java/tech/fastj/examples/model2d/Main.java
+++ b/examples/java/tech/fastj/examples/model2d/Main.java
@@ -40,7 +40,7 @@ public class Main extends SimpleManager {
 
         /* Super simple! Now, this alone does not cause the model to render to the screen. In order
          * for it to be rendered, you need to add it as a game object to the drawable manager. */
-        drawableManager.addGameObject(smallSquares);
+        drawableManager().addGameObject(smallSquares);
 
         /* If you comment out the line above, you'll see that the text does not get rendered. */
 
@@ -69,7 +69,7 @@ public class Main extends SimpleManager {
                 .build();
 
         // And of course, we need to add our model of squares to the drawable manager's game objects.
-        drawableManager.addGameObject(squaresTogether);
+        drawableManager().addGameObject(squaresTogether);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/mouse/Main.java
+++ b/examples/java/tech/fastj/examples/mouse/Main.java
@@ -42,7 +42,7 @@ public class Main extends SimpleManager {
          * To demonstrate each method, I've chosen to log whenever any of the methods is called. Run the program to see
          * this in action. */
 
-        inputManager.addMouseActionListener(new MouseActionListener() {
+        inputManager().addMouseActionListener(new MouseActionListener() {
             @Override
             public void onMousePressed(MouseButtonEvent mouseButtonEvent) {
                 FastJEngine.log("Mouse button {} pressed", mouseButtonEvent.getMouseButton());

--- a/examples/java/tech/fastj/examples/polygon2d/Main.java
+++ b/examples/java/tech/fastj/examples/polygon2d/Main.java
@@ -47,7 +47,7 @@ public class Main extends SimpleManager {
         /* Super simple! Now, this alone does not cause the square to render to the screen. In
          * order for it to be rendered, you need to add it as a game object to the drawable
          * manager. */
-        drawableManager.addGameObject(smallSquare);
+        drawableManager().addGameObject(smallSquare);
 
         /* If you comment out the line above, you'll see that the small square does not get
          * rendered. */
@@ -85,7 +85,7 @@ public class Main extends SimpleManager {
                 .build();
 
         // And of course, we need to add our large square to the drawable manager's game objects.
-        drawableManager.addGameObject(largeSquare);
+        drawableManager().addGameObject(largeSquare);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/rendersettings/Main.java
+++ b/examples/java/tech/fastj/examples/rendersettings/Main.java
@@ -49,7 +49,7 @@ public class Main extends SimpleManager {
         Text2D visualAid = Text2D.create("Render Settings are useful! (-.-)")
                 .withTransform(new Pointf(100f, 100f), Transform2D.DefaultRotation, new Pointf(3.0f, 3.0f))
                 .build();
-        drawableManager.addGameObject(visualAid);
+        drawableManager().addGameObject(visualAid);
     }
 
     @Override

--- a/examples/java/tech/fastj/examples/text2d/Main.java
+++ b/examples/java/tech/fastj/examples/text2d/Main.java
@@ -25,7 +25,7 @@ public class Main extends SimpleManager {
 
         /* Super simple! Now, this alone does not cause the text to render to the screen. In order
          * for it to be rendered, you need to add it as a game object to the drawable manager. */
-        drawableManager.addGameObject(message);
+        drawableManager().addGameObject(message);
 
         /* If you comment out the line above, you'll see that the text does not get rendered. */
 
@@ -58,7 +58,7 @@ public class Main extends SimpleManager {
                 .build();
 
         // And of course, we need to add our interesting text to the drawable manager's game objects.
-        drawableManager.addGameObject(interestingText2D);
+        drawableManager().addGameObject(interestingText2D);
     }
 
     @Override

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -60,6 +60,7 @@ module fastj.library {
     exports tech.fastj.systems.behaviors;
     exports tech.fastj.systems.control;
     exports tech.fastj.systems.collections;
+    exports tech.fastj.systems.execution;
     exports tech.fastj.systems.tags;
     exports tech.fastj.animation;
     exports tech.fastj.animation.sprite;

--- a/src/main/java/tech/fastj/animation/event/AnimationEvent.java
+++ b/src/main/java/tech/fastj/animation/event/AnimationEvent.java
@@ -1,10 +1,10 @@
 package tech.fastj.animation.event;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 import tech.fastj.animation.Animated;
 import tech.fastj.animation.AnimationData;
 
-public abstract class AnimationEvent<TD extends AnimationData, T extends Animated<TD>> extends GameEvent {
+public abstract class AnimationEvent<TD extends AnimationData, T extends Animated<TD>> extends Event {
 
     public abstract T getEventSource();
 }

--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -29,6 +29,7 @@ import tech.fastj.systems.audio.StreamedAudioPlayer;
 import tech.fastj.systems.behaviors.BehaviorManager;
 import tech.fastj.systems.collections.ManagedList;
 import tech.fastj.systems.control.LogicManager;
+import tech.fastj.systems.executor.FastJScheduledThreadPool;
 
 import tech.fastj.gameloop.CoreLoopState;
 import tech.fastj.gameloop.GameLoop;
@@ -40,7 +41,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -254,7 +254,7 @@ public class FastJEngine {
 
         fpsLog = new int[100];
         Arrays.fill(fpsLog, -1);
-        fpsLogger = Executors.newSingleThreadScheduledExecutor();
+        fpsLogger = new FastJScheduledThreadPool(1);
 
         setTargetFPS(engineConfig.targetFPS());
         setTargetUPS(engineConfig.targetUPS());
@@ -716,13 +716,12 @@ public class FastJEngine {
      * This logs the specified error message at the {@link LogLevel#Error error} level.
      *
      * @param errorMessage The error message to log.
-     * @param exception    The exception that caused a need for this method call.
+     * @param throwable    The exception that caused a need for this method call.
      * @see Log#error(String, Exception)
      */
-    public static void error(String errorMessage, Exception exception) {
+    public static void error(String errorMessage, Throwable throwable) {
         FastJEngine.forceCloseGame();
-        Log.error(FastJEngine.class, errorMessage, exception);
-        throw new IllegalStateException("ERROR: " + errorMessage, exception);
+        Log.error(FastJEngine.class, errorMessage, throwable);
     }
 
     /**

--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -181,6 +181,11 @@ public class FastJEngine {
         int fps;
         try {
             fps = DisplayUtil.getDefaultMonitorRefreshRate();
+
+            if (fps < 1) {
+                warning("Environment is not headless but monitor refresh rate was less than 1, will default FPS to 60.");
+                fps = 60;
+            }
         } catch (HeadlessException exception) {
             warning("Environment is headless, will default FPS to 60.");
             fps = 60;

--- a/src/main/java/tech/fastj/engine/FastJEngine.java
+++ b/src/main/java/tech/fastj/engine/FastJEngine.java
@@ -157,7 +157,10 @@ public class FastJEngine {
     public static final GameLoopState GeneralRender = new GameLoopState(
             CoreLoopState.LateUpdate,
             Integer.MAX_VALUE - 1,
-            (gameLoopState, deltaTime) -> gameManager.render(canvas)
+            (gameLoopState, deltaTime) -> {
+                gameManager.render(canvas);
+                drawFrames++;
+            }
     );
 
     private static final GameLoop GameLoop = new GameLoop(
@@ -177,7 +180,7 @@ public class FastJEngine {
     static {
         int fps;
         try {
-            fps = Math.max(60, DisplayUtil.getDefaultMonitorRefreshRate());
+            fps = DisplayUtil.getDefaultMonitorRefreshRate();
         } catch (HeadlessException exception) {
             warning("Environment is headless, will default FPS to 60.");
             fps = 60;

--- a/src/main/java/tech/fastj/gameloop/event/Event.java
+++ b/src/main/java/tech/fastj/gameloop/event/Event.java
@@ -1,6 +1,6 @@
 package tech.fastj.gameloop.event;
 
-public class GameEvent {
+public class Event {
 
     private boolean isConsumed = false;
     private final long timestamp = System.nanoTime();

--- a/src/main/java/tech/fastj/gameloop/event/EventHandler.java
+++ b/src/main/java/tech/fastj/gameloop/event/EventHandler.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Queue;
 
 @FunctionalInterface
-public interface GameEventHandler<T extends GameEvent, V extends GameEventObserver<T>> {
+public interface EventHandler<T extends Event, V extends EventObserver<T>> {
 
     default void handleEvents(List<V> gameEventObservers, Queue<T> gameEvents) {
         while (!gameEvents.isEmpty()) {

--- a/src/main/java/tech/fastj/gameloop/event/EventObserver.java
+++ b/src/main/java/tech/fastj/gameloop/event/EventObserver.java
@@ -1,6 +1,6 @@
 package tech.fastj.gameloop.event;
 
 @FunctionalInterface
-public interface GameEventObserver<T extends GameEvent> {
+public interface EventObserver<T extends Event> {
     void eventReceived(T event);
 }

--- a/src/main/java/tech/fastj/gameloop/event/GameEvent.java
+++ b/src/main/java/tech/fastj/gameloop/event/GameEvent.java
@@ -3,6 +3,7 @@ package tech.fastj.gameloop.event;
 public class GameEvent {
 
     private boolean isConsumed = false;
+    private final long timestamp = System.nanoTime();
 
     public boolean isConsumed() {
         return isConsumed;
@@ -10,5 +11,9 @@ public class GameEvent {
 
     public void consume() {
         isConsumed = true;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 }

--- a/src/main/java/tech/fastj/graphics/Drawable.java
+++ b/src/main/java/tech/fastj/graphics/Drawable.java
@@ -5,8 +5,7 @@ import tech.fastj.math.Transform2D;
 
 import tech.fastj.graphics.util.DrawUtil;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 import tech.fastj.systems.tags.TaggableEntity;
 
 import java.awt.geom.AffineTransform;
@@ -56,16 +55,7 @@ public abstract class Drawable extends TaggableEntity {
      *
      * @param origin The origin of this {@code Drawable}.
      */
-    public abstract void destroy(Scene origin);
-
-    /**
-     * Destroys all memory the {@code Drawable} uses.
-     * <p>
-     * This also removes any internal references that the {@code Drawable} may have.
-     *
-     * @param origin The origin of this {@code Drawable}.
-     */
-    public abstract void destroy(SimpleManager origin);
+    public abstract void destroy(GameHandler origin);
 
     /**
      * Gets the collision path of the {@code Drawable}.
@@ -435,25 +425,11 @@ public abstract class Drawable extends TaggableEntity {
 
     /**
      * Destroys the {@code Drawable}'s {@code Drawable} components, as well as any references the {@code Drawable} has
-     * within the {@code Scene} parameter.
+     * within the {@code GameHandler} parameter.
      *
-     * @param origin {@code Scene} parameter that will have all references to this {@code Drawable} removed.
+     * @param origin {@code GameHandler} parameter that will have all references to this {@code Drawable} removed.
      */
-    protected void destroyTheRest(Scene origin) {
-        transform.reset();
-        clearTags();
-
-        collisionPath = null;
-        isDestroyed = true;
-    }
-
-    /**
-     * Destroys the {@code Drawable}'s {@code Drawable} components, as well as any references the {@code Drawable} has
-     * within the {@code SimpleManager} parameter.
-     *
-     * @param origin {@code SimpleManager} parameter that will have all references to this {@code Drawable} removed.
-     */
-    protected void destroyTheRest(SimpleManager origin) {
+    protected void destroyTheRest(GameHandler origin) {
         transform.reset();
         clearTags();
 

--- a/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
+++ b/src/main/java/tech/fastj/graphics/display/DisplayEvent.java
@@ -1,11 +1,11 @@
 package tech.fastj.graphics.display;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
 
-public class DisplayEvent<T extends Display> extends GameEvent {
+public class DisplayEvent<T extends Display> extends Event {
 
     private final DisplayEventType eventType;
     private final ComponentEvent rawEvent;

--- a/src/main/java/tech/fastj/graphics/display/DisplayEventListener.java
+++ b/src/main/java/tech/fastj/graphics/display/DisplayEventListener.java
@@ -1,8 +1,8 @@
 package tech.fastj.graphics.display;
 
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventObserver;
 
-public interface DisplayEventListener<T extends Display> extends GameEventObserver<DisplayEvent<T>> {
+public interface DisplayEventListener<T extends Display> extends EventObserver<DisplayEvent<T>> {
 
     default void displayMoved(DisplayEvent<T> displayEvent) {
     }

--- a/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
+++ b/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
@@ -69,7 +69,7 @@ public class SimpleDisplay implements Display {
                 DisplayEvent<SimpleDisplay> displayEvent = new DisplayEvent<>(DisplayEventType.Closing, windowEvent, display);
                 FastJEngine.getGameLoop().fireEvent(displayEvent);
 
-                FastJEngine.runAfterRender(FastJEngine::closeGame);
+                FastJEngine.runLater(FastJEngine::closeGame);
                 display.close();
             }
 

--- a/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
+++ b/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
@@ -1,17 +1,18 @@
 package tech.fastj.graphics.display;
 
 import tech.fastj.engine.FastJEngine;
-
 import tech.fastj.math.Point;
 
+import javax.swing.JFrame;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
+import java.util.concurrent.TimeUnit;
 
-import javax.swing.JFrame;
+import tech.fastj.gameloop.CoreLoopState;
 
 /**
  * A simple implementation of {@link Display} which includes the following features:
@@ -69,8 +70,16 @@ public class SimpleDisplay implements Display {
                 DisplayEvent<SimpleDisplay> displayEvent = new DisplayEvent<>(DisplayEventType.Closing, windowEvent, display);
                 FastJEngine.getGameLoop().fireEvent(displayEvent);
 
+                // TODO: find out why this only works as intended during FixedUpdate
+                while (FastJEngine.getGameLoop().getCurrentGameLoopState().getCoreLoopState() != CoreLoopState.FixedUpdate) {
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(1L);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
                 FastJEngine.runLater(FastJEngine::closeGame);
-                display.close();
             }
 
             @Override

--- a/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
+++ b/src/main/java/tech/fastj/graphics/display/SimpleDisplay.java
@@ -1,9 +1,11 @@
 package tech.fastj.graphics.display;
 
 import tech.fastj.engine.FastJEngine;
+
 import tech.fastj.math.Point;
 
-import javax.swing.JFrame;
+import tech.fastj.gameloop.CoreLoopState;
+
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.event.ComponentAdapter;
@@ -12,7 +14,7 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.util.concurrent.TimeUnit;
 
-import tech.fastj.gameloop.CoreLoopState;
+import javax.swing.JFrame;
 
 /**
  * A simple implementation of {@link Display} which includes the following features:

--- a/src/main/java/tech/fastj/graphics/game/GameObject.java
+++ b/src/main/java/tech/fastj/graphics/game/GameObject.java
@@ -5,8 +5,7 @@ import tech.fastj.graphics.Drawable;
 import tech.fastj.systems.behaviors.Behavior;
 import tech.fastj.systems.behaviors.BehaviorHandler;
 import tech.fastj.systems.collections.ManagedList;
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Graphics2D;
 import java.util.List;
@@ -139,32 +138,15 @@ public abstract class GameObject extends Drawable {
     public abstract void render(Graphics2D g);
 
     /**
-     * Destroys all references of the {@code GameObject}'s behaviors and removes its references from the scene.
+     * Destroys all references of the {@code GameObject}'s behaviors and removes its references from the {@link GameHandler}.
      *
-     * @param origin {@code Scene} parameter that will have all references to this {@code GameObject} removed.
+     * @param origin {@code GameHandler} parameter that will have all references to this {@code GameObject} removed.
      */
     @Override
-    protected void destroyTheRest(Scene origin) {
+    protected void destroyTheRest(GameHandler origin) {
         super.destroyTheRest(origin);
 
-        origin.drawableManager.removeGameObject(this);
-        origin.removeBehaviorListener(this);
-
-        destroyAllBehaviors();
-        clearAllBehaviors();
-    }
-
-    /**
-     * Destroys all references of the {@code GameObject}'s behaviors and removes its references from the
-     * {@code SimpleManager}.
-     *
-     * @param origin {@code SimpleManager} parameter that will have all references to this {@code GameObject} removed.
-     */
-    @Override
-    protected void destroyTheRest(SimpleManager origin) {
-        super.destroyTheRest(origin);
-
-        origin.drawableManager.removeGameObject(this);
+        origin.drawableManager().removeGameObject(this);
         origin.removeBehaviorListener(this);
 
         destroyAllBehaviors();

--- a/src/main/java/tech/fastj/graphics/game/Light2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Light2D.java
@@ -5,8 +5,7 @@ import tech.fastj.math.Pointf;
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.util.DrawUtil;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.AlphaComposite;
 import java.awt.Composite;
@@ -34,12 +33,7 @@ public class Light2D extends GameObject {
     }
 
     @Override
-    public void destroy(Scene origin) {
-        super.destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
         super.destroyTheRest(origin);
     }
 

--- a/src/main/java/tech/fastj/graphics/game/Model2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Model2D.java
@@ -3,8 +3,7 @@ package tech.fastj.graphics.game;
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.util.DrawUtil;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
@@ -88,16 +87,7 @@ public class Model2D extends GameObject {
     }
 
     @Override
-    public void destroy(Scene origin) {
-        for (Polygon2D polygon : polygons) {
-            polygon.destroy(origin);
-        }
-
-        super.destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
         for (Polygon2D polygon : polygons) {
             polygon.destroy(origin);
         }

--- a/src/main/java/tech/fastj/graphics/game/Polygon2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Polygon2D.java
@@ -7,8 +7,7 @@ import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.util.DrawUtil;
 
 import tech.fastj.systems.collections.Pair;
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -373,19 +372,7 @@ public class Polygon2D extends GameObject {
     }
 
     @Override
-    public void destroy(Scene origin) {
-        originalPoints = new Pointf[]{};
-
-        renderStyle = DefaultRenderStyle;
-        fillPaint = DefaultFill;
-        outlineColor = DefaultOutlineColor;
-        outlineStroke = DefaultOutlineStroke;
-
-        super.destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
         originalPoints = new Pointf[]{};
 
         renderStyle = DefaultRenderStyle;

--- a/src/main/java/tech/fastj/graphics/game/Sprite2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Sprite2D.java
@@ -10,8 +10,7 @@ import tech.fastj.logging.Log;
 import tech.fastj.resources.images.ImageResource;
 import tech.fastj.resources.images.ImageUtil;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
@@ -256,21 +255,7 @@ public class Sprite2D extends GameObject implements Animated<SpriteAnimationData
     }
 
     @Override
-    public void destroy(Scene origin) {
-        setPaused(true);
-
-        animationDataMap.clear();
-        animationDataMap.putAll(NoAnimationsLoaded);
-        currentAnimation = NoAnimation;
-        sprites = NoSpritesLoaded;
-        currentFrame = DefaultStartingFrame;
-        animationFPS = DefaultAnimationFPS;
-
-        super.destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
         setPaused(true);
 
         animationDataMap.clear();

--- a/src/main/java/tech/fastj/graphics/game/Sprite2DBuilder.java
+++ b/src/main/java/tech/fastj/graphics/game/Sprite2DBuilder.java
@@ -7,6 +7,8 @@ import tech.fastj.math.Transform2D;
 
 import tech.fastj.resources.images.ImageResource;
 
+import tech.fastj.gameloop.CoreLoopState;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -117,7 +119,7 @@ public class Sprite2DBuilder {
 
         FastJEngine.getAnimationEngine(Sprite2D.class).addAnimated(sprite2D);
         if (!startPaused) {
-            FastJEngine.runAfterUpdate(() -> sprite2D.setPaused(false));
+            FastJEngine.runLater(() -> sprite2D.setPaused(false), CoreLoopState.FixedUpdate);
         }
 
         return sprite2D;

--- a/src/main/java/tech/fastj/graphics/game/Text2D.java
+++ b/src/main/java/tech/fastj/graphics/game/Text2D.java
@@ -5,8 +5,7 @@ import tech.fastj.math.Transform2D;
 
 import tech.fastj.graphics.Drawable;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -179,17 +178,7 @@ public class Text2D extends GameObject {
     }
 
     @Override
-    public void destroy(Scene origin) {
-        text = DefaultText;
-        fillPaint = DefaultFill;
-        font = DefaultFont;
-        hasMetrics = false;
-
-        super.destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
         text = DefaultText;
         fillPaint = DefaultFill;
         font = DefaultFont;

--- a/src/main/java/tech/fastj/graphics/ui/UIElement.java
+++ b/src/main/java/tech/fastj/graphics/ui/UIElement.java
@@ -5,8 +5,7 @@ import tech.fastj.graphics.display.Camera;
 
 import tech.fastj.input.InputActionEvent;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
@@ -29,21 +28,11 @@ public abstract class UIElement<T extends InputActionEvent> extends Drawable {
     /**
      * Instantiates the {@code UIElement}'s internals, and adds it to the origin scene as a ui element.
      *
-     * @param origin The scene which this UIElement is tied to.
+     * @param origin The game handler which this UIElement is tied to.
      */
-    protected UIElement(Scene origin) {
+    protected UIElement(GameHandler origin) {
         onActionEvents = new ArrayList<>();
-        origin.drawableManager.addUIElement(this);
-    }
-
-    /**
-     * Instantiates the {@code UIElement}'s internals, and adds it to the origin scene as a ui element.
-     *
-     * @param origin The scene which this UIElement is tied to.
-     */
-    protected UIElement(SimpleManager origin) {
-        onActionEvents = new ArrayList<>();
-        origin.drawableManager.addUIElement(this);
+        origin.drawableManager().addUIElement(this);
     }
 
     /**
@@ -112,22 +101,11 @@ public abstract class UIElement<T extends InputActionEvent> extends Drawable {
     /**
      * Removes the {@code UIElement}'s references in the specified scene as a GUI object.
      *
-     * @param origin {@code Scene} parameter that will have all references to this {@code UIElement} removed.
+     * @param origin {@code GameHandler} parameter that will have all references to this {@code UIElement} removed.
      */
     @Override
-    protected void destroyTheRest(Scene origin) {
+    protected void destroyTheRest(GameHandler origin) {
         super.destroyTheRest(origin);
-        origin.drawableManager.removeUIElement(this);
-    }
-
-    /**
-     * Removes the {@code UIElement}'s references in the specified {@code SimpleManager} as a GUI object.
-     *
-     * @param origin {@code SimpleManager} parameter that will have all references to this {@code UIElement} removed.
-     */
-    @Override
-    protected void destroyTheRest(SimpleManager origin) {
-        super.destroyTheRest(origin);
-        origin.drawableManager.removeUIElement(this);
+        origin.drawableManager().removeUIElement(this);
     }
 }

--- a/src/main/java/tech/fastj/graphics/ui/elements/Button.java
+++ b/src/main/java/tech/fastj/graphics/ui/elements/Button.java
@@ -13,8 +13,7 @@ import tech.fastj.input.mouse.MouseActionListener;
 import tech.fastj.input.mouse.MouseButtons;
 import tech.fastj.input.mouse.events.MouseButtonEvent;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -55,29 +54,20 @@ public class Button extends UIElement<MouseButtonEvent> implements MouseActionLi
     /**
      * Constructs a button with a default location and size.
      *
-     * @param origin The scene to add the button as a gui object to.
+     * @param origin The game handler to add the button as a gui object to.
      */
-    public Button(Scene origin) {
-        this(origin, Transform2D.DefaultTranslation, DefaultSize);
-    }
-
-    /**
-     * Constructs a button with a default location and size.
-     *
-     * @param origin The simple manager to add the button as a gui object to.
-     */
-    public Button(SimpleManager origin) {
+    public Button(GameHandler origin) {
         this(origin, Transform2D.DefaultTranslation, DefaultSize);
     }
 
     /**
      * Constructs a button with the specified location and initial size.
      *
-     * @param origin      The scene to add the button as a gui object to.
+     * @param origin      The game handler to add the button as a gui object to.
      * @param location    The location to create the button at.
      * @param initialSize The initial size of the button, though the button will get larger if the text outgrows it.
      */
-    public Button(Scene origin, Pointf location, Pointf initialSize) {
+    public Button(GameHandler origin, Pointf location, Pointf initialSize) {
         super(origin);
         if (initialSize.x < Maths.FloatPrecision || initialSize.y < Maths.FloatPrecision) {
             throw new IllegalArgumentException(
@@ -101,41 +91,7 @@ public class Button extends UIElement<MouseButtonEvent> implements MouseActionLi
         setMetrics(graphics);
         graphics.dispose();
 
-        origin.inputManager.addMouseActionListener(this);
-    }
-
-    /**
-     * Constructs a button with the specified location and initial size.
-     *
-     * @param origin      The simple manager to add the button as a gui object to.
-     * @param location    The location to create the button at.
-     * @param initialSize The initial size of the button, though the button will get larger if the text outgrows it.
-     */
-    public Button(SimpleManager origin, Pointf location, Pointf initialSize) {
-        super(origin);
-        if (initialSize.x < Maths.FloatPrecision || initialSize.y < Maths.FloatPrecision) {
-            throw new IllegalArgumentException(
-                    "The size " + initialSize + " is too small." +
-                            System.lineSeparator() +
-                            "The minimum size in both x and y directions is " + Maths.FloatPrecision + "."
-            );
-        }
-
-        super.setOnActionCondition(event -> Mouse.interactsWith(Button.this, MouseAction.Press) && Mouse.isMouseButtonPressed(MouseButtons.Left));
-
-        Pointf[] buttonCoords = DrawUtil.createBox(Pointf.origin(), initialSize);
-        super.setCollisionPath(DrawUtil.createPath(buttonCoords));
-
-        this.paint = DefaultFill;
-        this.font = DefaultFont;
-        this.text = DefaultText;
-
-        translate(location);
-        Graphics2D graphics = GraphicsHelper.createGraphics();
-        setMetrics(graphics);
-        graphics.dispose();
-
-        origin.inputManager.addMouseActionListener(this);
+        origin.inputManager().addMouseActionListener(this);
     }
 
     /**
@@ -258,17 +214,10 @@ public class Button extends UIElement<MouseButtonEvent> implements MouseActionLi
     }
 
     @Override
-    public void destroy(Scene origin) {
+    public void destroy(GameHandler origin) {
         super.destroyTheRest(origin);
         paint = null;
-        origin.inputManager.removeMouseActionListener(this);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
-        super.destroyTheRest(origin);
-        paint = null;
-        origin.inputManager.removeMouseActionListener(this);
+        origin.inputManager().removeMouseActionListener(this);
     }
 
     /**

--- a/src/main/java/tech/fastj/input/InputActionEvent.java
+++ b/src/main/java/tech/fastj/input/InputActionEvent.java
@@ -1,9 +1,9 @@
 package tech.fastj.input;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 
 import java.awt.event.InputEvent;
 
-public abstract class InputActionEvent extends GameEvent {
+public abstract class InputActionEvent extends Event {
     public abstract InputEvent getRawEvent();
 }

--- a/src/main/java/tech/fastj/input/InputManager.java
+++ b/src/main/java/tech/fastj/input/InputManager.java
@@ -36,7 +36,7 @@ public class InputManager {
      */
     @SuppressWarnings("unchecked")
     public List<KeyboardActionListener> getKeyboardActionListeners() {
-        return (List) FastJEngine.getGameLoop().getGameEventObservers(KeyboardActionEvent.class);
+        return (List) FastJEngine.getGameLoop().getEventObservers(KeyboardActionEvent.class);
     }
 
     /**
@@ -46,7 +46,7 @@ public class InputManager {
      */
     @SuppressWarnings("unchecked")
     public List<? extends MouseActionListener> getMouseActionListeners() {
-        return (List) FastJEngine.getGameLoop().getGameEventObservers(MouseActionEvent.class);
+        return (List) FastJEngine.getGameLoop().getEventObservers(MouseActionEvent.class);
     }
 
     /* Key Action Listeners */

--- a/src/main/java/tech/fastj/input/keyboard/Keyboard.java
+++ b/src/main/java/tech/fastj/input/keyboard/Keyboard.java
@@ -9,6 +9,8 @@ import tech.fastj.input.keyboard.events.KeyboardTypedEvent;
 import tech.fastj.logging.Log;
 import tech.fastj.logging.LogLevel;
 
+import tech.fastj.systems.execution.FastJScheduledThreadPool;
+
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.Collections;
@@ -16,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -87,7 +88,7 @@ public class Keyboard implements KeyListener {
             Log.debug(Keyboard.class, "Initializing {}", Keyboard.class.getName());
         }
 
-        keyChecker = Executors.newSingleThreadScheduledExecutor();
+        keyChecker = new FastJScheduledThreadPool(1);
         keyChecker.scheduleWithFixedDelay(Keyboard::keyCheck, 1, 1, TimeUnit.MILLISECONDS);
         FastJEngine.getGameLoop().addClassAlias(KeyboardStateEvent.class, KeyboardActionEvent.class);
         FastJEngine.getGameLoop().addClassAlias(KeyboardTypedEvent.class, KeyboardActionEvent.class);

--- a/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
+++ b/src/main/java/tech/fastj/input/keyboard/KeyboardActionListener.java
@@ -4,14 +4,14 @@ import tech.fastj.input.keyboard.events.KeyboardActionEvent;
 import tech.fastj.input.keyboard.events.KeyboardStateEvent;
 import tech.fastj.input.keyboard.events.KeyboardTypedEvent;
 
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventObserver;
 
 import java.awt.event.KeyEvent;
 import java.util.Set;
 
 /**
  * A keyboard action listener.
- *
+ * <p>
  * <b>NOTE:</b> For use with a FastJ {@code Scene}, a keyboard action listener must be added to a
  * {@code Scene}'s list of keyboard action listeners.
  * <br>
@@ -22,7 +22,7 @@ import java.util.Set;
  * @author Andrew Dey
  * @since 1.0.0
  */
-public interface KeyboardActionListener extends GameEventObserver<KeyboardActionEvent> {
+public interface KeyboardActionListener extends EventObserver<KeyboardActionEvent> {
 
     /** Event called when a key is currently pressed, once per game update. */
     default void onKeyDown(Set<Keys> keysDown) {

--- a/src/main/java/tech/fastj/input/mouse/Mouse.java
+++ b/src/main/java/tech/fastj/input/mouse/Mouse.java
@@ -16,6 +16,8 @@ import tech.fastj.input.mouse.events.MouseWindowEvent;
 import tech.fastj.logging.Log;
 import tech.fastj.logging.LogLevel;
 
+import tech.fastj.systems.execution.FastJScheduledThreadPool;
+
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
@@ -25,7 +27,6 @@ import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -46,7 +47,7 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
     private static final int InitialWheelRotation = 0;
     private static final int InitialClickCount = 0;
 
-    private static ScheduledExecutorService mouseExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    private static ScheduledExecutorService mouseExecutor = new FastJScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
     private static int buttonLastPressed = Mouse.InitialMouseButton;
     private static int buttonLastReleased = Mouse.InitialMouseButton;
@@ -165,7 +166,7 @@ public class Mouse implements MouseListener, MouseMotionListener, MouseWheelList
             Log.debug(Mouse.class, "Initializing {}", Mouse.class.getName());
         }
 
-        mouseExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+        mouseExecutor = new FastJScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
         FastJEngine.getGameLoop().addClassAlias(MouseWindowEvent.class, MouseActionEvent.class);
         FastJEngine.getGameLoop().addClassAlias(MouseScrollEvent.class, MouseActionEvent.class);

--- a/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
+++ b/src/main/java/tech/fastj/input/mouse/MouseActionListener.java
@@ -6,11 +6,11 @@ import tech.fastj.input.mouse.events.MouseMotionEvent;
 import tech.fastj.input.mouse.events.MouseScrollEvent;
 import tech.fastj.input.mouse.events.MouseWindowEvent;
 
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventObserver;
 
 /**
  * A mouse action listener.
- *
+ * <p>
  * <b>NOTE:</b> For use with a FastJ {@code Scene}, a mouse action listener must be added to a
  * {@code Scene}'s list of mouse action listeners.
  * <br>
@@ -21,7 +21,7 @@ import tech.fastj.gameloop.event.GameEventObserver;
  * @author Andrew Dey
  * @since 1.0.0
  */
-public interface MouseActionListener extends GameEventObserver<MouseActionEvent> {
+public interface MouseActionListener extends EventObserver<MouseActionEvent> {
 
     /**
      * Event called when a mouse button is pressed.

--- a/src/main/java/tech/fastj/logging/Log.java
+++ b/src/main/java/tech/fastj/logging/Log.java
@@ -148,9 +148,9 @@ public class Log {
      * @param <T>          The type of the class to get the logging instance of.
      * @param loggingClass The class to get the logging instance of.
      * @param message      The error message to log.
-     * @param exception    The {@code Exception} causing a need to log the error.
+     * @param throwable    The {@code Throwable} causing a need to log the error.
      */
-    public static <T> void error(Class<T> loggingClass, String message, Exception exception) {
-        LoggerFactory.getLogger(loggingClass).error(message, exception);
+    public static <T> void error(Class<T> loggingClass, String message, Throwable throwable) {
+        LoggerFactory.getLogger(loggingClass).error(message, throwable);
     }
 }

--- a/src/main/java/tech/fastj/systems/audio/AudioEvent.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEvent.java
@@ -2,11 +2,11 @@ package tech.fastj.systems.audio;
 
 import tech.fastj.systems.audio.state.PlaybackState;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 
 import javax.sound.sampled.LineEvent;
 
-public class AudioEvent extends GameEvent {
+public class AudioEvent extends Event {
 
     private final LineEvent rawEvent;
     private final Audio eventSource;

--- a/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioEventListener.java
@@ -4,7 +4,7 @@ import tech.fastj.engine.FastJEngine;
 
 import tech.fastj.systems.audio.state.PlaybackState;
 
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventObserver;
 
 import java.util.Map;
 import java.util.Objects;
@@ -19,7 +19,7 @@ import javax.sound.sampled.LineEvent;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public class AudioEventListener implements GameEventObserver<AudioEvent> {
+public class AudioEventListener implements EventObserver<AudioEvent> {
 
     private Consumer<AudioEvent> audioOpenAction;
     private Consumer<AudioEvent> audioCloseAction;

--- a/src/main/java/tech/fastj/systems/audio/AudioManager.java
+++ b/src/main/java/tech/fastj/systems/audio/AudioManager.java
@@ -7,8 +7,8 @@ import tech.fastj.resources.files.FileUtil;
 import tech.fastj.systems.audio.state.PlaybackState;
 import tech.fastj.systems.tags.TagHandler;
 
-import tech.fastj.gameloop.event.GameEventHandler;
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventHandler;
+import tech.fastj.gameloop.event.EventObserver;
 
 import java.io.IOException;
 import java.net.URL;
@@ -26,7 +26,7 @@ import javax.sound.sampled.*;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEvent, GameEventObserver<AudioEvent>> {
+public class AudioManager implements TagHandler<Audio>, EventHandler<AudioEvent, EventObserver<AudioEvent>> {
 
     private final Map<String, MemoryAudio> memoryAudioFiles = new ConcurrentHashMap<>();
     private final Map<String, StreamedAudio> streamedAudioFiles = new ConcurrentHashMap<>();
@@ -354,10 +354,10 @@ public class AudioManager implements TagHandler<Audio>, GameEventHandler<AudioEv
     }
 
     @Override
-    public void handleEvent(List<GameEventObserver<AudioEvent>> gameEventObservers, AudioEvent audioEvent) {
-        for (GameEventObserver<AudioEvent> gameEventObserver : gameEventObservers) {
-            if (audioEvent.getEventSource().getAudioEventListener().equals(gameEventObserver)) {
-                gameEventObserver.eventReceived(audioEvent);
+    public void handleEvent(List<EventObserver<AudioEvent>> eventObservers, AudioEvent audioEvent) {
+        for (EventObserver<AudioEvent> eventObserver : eventObservers) {
+            if (audioEvent.getEventSource().getAudioEventListener().equals(eventObserver)) {
+                eventObserver.eventReceived(audioEvent);
                 return;
             }
         }

--- a/src/main/java/tech/fastj/systems/collections/ManagedList.java
+++ b/src/main/java/tech/fastj/systems/collections/ManagedList.java
@@ -133,7 +133,6 @@ public class ManagedList<E> implements List<E> {
     public void run(Consumer<ArrayList<E>> action) {
         try {
             listManager.submit(() -> {
-                System.out.println("accept " + uuid);
                 action.accept(list);
             }).get();
         } catch (InterruptedException exception) {
@@ -157,7 +156,6 @@ public class ManagedList<E> implements List<E> {
         try {
             listManager.submit(
                     () -> {
-                        System.out.println("access " + uuid);
                         for (E element : list) {
                             action.accept(element);
                         }
@@ -184,7 +182,6 @@ public class ManagedList<E> implements List<E> {
      */
     public ScheduledFuture<?> schedule(Consumer<ArrayList<E>> action, long delay, TimeUnit unit) {
         return listManager.schedule(() -> {
-            System.out.println("accept scheduled " + uuid);
             action.accept(list);
         }, delay, unit);
     }
@@ -204,7 +201,6 @@ public class ManagedList<E> implements List<E> {
     public ScheduledFuture<?> scheduleIterate(Consumer<E> action, long delay, TimeUnit unit) {
         return listManager.schedule(
                 () -> {
-                    System.out.println("access scheduled " + uuid);
                     for (E element : list) {
                         action.accept(element);
                     }
@@ -231,7 +227,6 @@ public class ManagedList<E> implements List<E> {
      */
     public ScheduledFuture<?> scheduleAtFixedRate(Consumer<ArrayList<E>> action, long initialDelay, long period, TimeUnit unit) {
         return listManager.scheduleAtFixedRate(() -> {
-            System.out.println("accept fixed rate " + uuid);
             action.accept(list);
         }, initialDelay, period, unit);
     }
@@ -254,7 +249,6 @@ public class ManagedList<E> implements List<E> {
     public ScheduledFuture<?> scheduledIterateAtFixedRate(Consumer<E> action, long initialDelay, long period, TimeUnit unit) {
         return listManager.scheduleAtFixedRate(
                 () -> {
-                    System.out.println("access scheduled " + uuid);
                     for (E element : list) {
                         action.accept(element);
                     }
@@ -282,7 +276,6 @@ public class ManagedList<E> implements List<E> {
      */
     public ScheduledFuture<?> scheduleWithFixedDelay(Consumer<ArrayList<E>> action, long initialDelay, long delay, TimeUnit unit) {
         return listManager.scheduleWithFixedDelay(() -> {
-            System.out.println("accept fixed delay " + uuid);
             action.accept(list);
         }, initialDelay, delay, unit);
     }
@@ -306,7 +299,6 @@ public class ManagedList<E> implements List<E> {
     public ScheduledFuture<?> scheduledIterateWithFixedDelay(Consumer<E> action, long initialDelay, long delay, TimeUnit unit) {
         return listManager.scheduleWithFixedDelay(
                 () -> {
-                    System.out.println("access fixed delay " + uuid);
                     for (E element : list) {
                         action.accept(element);
                     }

--- a/src/main/java/tech/fastj/systems/control/DrawableManager.java
+++ b/src/main/java/tech/fastj/systems/control/DrawableManager.java
@@ -122,13 +122,13 @@ public class DrawableManager {
     }
 
     public void destroyGameObjects(SimpleManager manager) {
-        for (GameObject gameObject : gameObjects.values()) {
+        for (GameObject gameObject : getGameObjectsList()) {
             gameObject.destroy(manager);
         }
     }
 
     public void destroyGameObjects(Scene scene) {
-        for (GameObject gameObject : gameObjects.values()) {
+        for (GameObject gameObject : getGameObjectsList()) {
             gameObject.destroy(scene);
         }
     }
@@ -173,13 +173,13 @@ public class DrawableManager {
     }
 
     public void destroyUIElements(SimpleManager manager) {
-        for (UIElement<? extends InputActionEvent> uiElement : uiElements.values()) {
+        for (UIElement<? extends InputActionEvent> uiElement : getUIElementsList()) {
             uiElement.destroy(manager);
         }
     }
 
     public void destroyUIElements(Scene scene) {
-        for (UIElement<? extends InputActionEvent> uiElement : uiElements.values()) {
+        for (UIElement<? extends InputActionEvent> uiElement : getUIElementsList()) {
             uiElement.destroy(scene);
         }
     }
@@ -196,14 +196,18 @@ public class DrawableManager {
 
     /* reset */
 
-    public void destroyAllLists(Scene scene) {
+    public void reset(Scene scene) {
         destroyGameObjects(scene);
         destroyUIElements(scene);
+
+        clearAllLists();
     }
 
-    public void destroyAllLists(SimpleManager manager) {
+    public void reset(SimpleManager manager) {
         destroyGameObjects(manager);
         destroyUIElements(manager);
+
+        clearAllLists();
     }
 
     /** Removes all game objects and ui elements from the manager. */

--- a/src/main/java/tech/fastj/systems/control/GameHandler.java
+++ b/src/main/java/tech/fastj/systems/control/GameHandler.java
@@ -4,6 +4,7 @@ import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 
 import tech.fastj.input.InputManager;
+
 import tech.fastj.systems.behaviors.BehaviorHandler;
 import tech.fastj.systems.tags.TagHandler;
 

--- a/src/main/java/tech/fastj/systems/control/GameHandler.java
+++ b/src/main/java/tech/fastj/systems/control/GameHandler.java
@@ -1,0 +1,28 @@
+package tech.fastj.systems.control;
+
+import tech.fastj.graphics.Drawable;
+import tech.fastj.graphics.display.Camera;
+
+import tech.fastj.input.InputManager;
+import tech.fastj.systems.behaviors.BehaviorHandler;
+import tech.fastj.systems.tags.TagHandler;
+
+public interface GameHandler extends BehaviorHandler, TagHandler<Drawable> {
+
+    DrawableManager drawableManager();
+
+    InputManager inputManager();
+
+    Camera getCamera();
+
+    /**
+     * Resets the game handler entirely.
+     * <p>
+     * This method is called when the engine exits. Due to the game engine's mutability, it is preferred that all resources of the game
+     * engine are removed gracefully.
+     * <p>
+     * <b>FOR IMPLEMENTORS:</b> By the end of this method call, the game handler should have released all its
+     * resources.
+     */
+    void reset();
+}

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -1,5 +1,7 @@
 package tech.fastj.systems.control;
 
+import tech.fastj.engine.FastJEngine;
+
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 import tech.fastj.graphics.display.FastJCanvas;
@@ -128,11 +130,16 @@ public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
     void generalLoad(FastJCanvas canvas) {
         inputManager.load();
         load(canvas);
+
+        setInitialized(true);
     }
 
     void generalUnload(FastJCanvas canvas) {
         inputManager.unload();
         unload(canvas);
+        drawableManager.reset(this);
+
+        setInitialized(false);
     }
 
     /* Reset */
@@ -140,16 +147,15 @@ public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
     /** Removes all elements from the scene. */
     public void clearAllLists() {
         drawableManager.clearAllLists();
-        this.clearBehaviorListeners();
+        clearBehaviorListeners();
     }
 
     /** Resets the scene's state entirely. */
     public void reset() {
-        this.setInitialized(false);
-        this.destroyBehaviorListeners();
-        drawableManager.destroyAllLists(this);
+        generalUnload(FastJEngine.getCanvas());
+
+        clearAllLists();
         inputManager.reset();
-        this.clearAllLists();
         camera.reset();
     }
 }

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -1,11 +1,13 @@
 package tech.fastj.systems.control;
 
 import tech.fastj.engine.FastJEngine;
+
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 import tech.fastj.graphics.display.FastJCanvas;
 
 import tech.fastj.input.InputManager;
+
 import tech.fastj.systems.behaviors.BehaviorManager;
 
 import java.util.List;

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -24,9 +24,18 @@ public abstract class Scene implements GameHandler {
     private final String sceneName;
     private final Camera camera;
 
-    /** Input manager instance for the scene -- it controls the scene's received events. */
+    /**
+     * Input manager instance for the scene -- it controls the scene's received events.
+     * @deprecated Public access to this field will be removed soon -- please use {@link GameHandler#inputManager()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public final InputManager inputManager;
-    /** Drawable manager instance for the scene -- it controls the scene's game objects and ui elements. */
+
+    /**
+     * Drawable manager instance for the scene -- it controls the scene's game objects and ui elements.
+     * @deprecated Public access to this field will be removed soon -- please use {@link GameHandler#drawableManager()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public final DrawableManager drawableManager;
 
     private boolean isInitialized;

--- a/src/main/java/tech/fastj/systems/control/Scene.java
+++ b/src/main/java/tech/fastj/systems/control/Scene.java
@@ -1,16 +1,12 @@
 package tech.fastj.systems.control;
 
 import tech.fastj.engine.FastJEngine;
-
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.display.Camera;
 import tech.fastj.graphics.display.FastJCanvas;
 
 import tech.fastj.input.InputManager;
-
-import tech.fastj.systems.behaviors.BehaviorHandler;
 import tech.fastj.systems.behaviors.BehaviorManager;
-import tech.fastj.systems.tags.TagHandler;
 
 import java.util.List;
 
@@ -23,7 +19,7 @@ import java.util.List;
  * @author Andrew Dey
  * @since 1.0.0
  */
-public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
+public abstract class Scene implements GameHandler {
 
     private final String sceneName;
     private final Camera camera;
@@ -100,8 +96,19 @@ public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
      *
      * @return The camera of the scene.
      */
+    @Override
     public Camera getCamera() {
         return camera;
+    }
+
+    @Override
+    public InputManager inputManager() {
+        return inputManager;
+    }
+
+    @Override
+    public DrawableManager drawableManager() {
+        return drawableManager;
     }
 
     /**
@@ -151,6 +158,7 @@ public abstract class Scene implements BehaviorHandler, TagHandler<Drawable> {
     }
 
     /** Resets the scene's state entirely. */
+    @Override
     public void reset() {
         generalUnload(FastJEngine.getCanvas());
 

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -407,13 +407,11 @@ public abstract class SceneManager implements LogicManager {
      */
     private void sceneNameAlreadyExistsCheck(String sceneName) {
         if (scenes.containsKey(sceneName)) {
-            IllegalArgumentException e = new IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "The scene name \"" + sceneName + "\" is already in use."
                             + System.lineSeparator()
                             + "Scenes added: " + scenes.keySet()
             );
-
-            FastJEngine.error(CrashMessages.SceneError.errorMessage, e);
         }
     }
 
@@ -427,10 +425,7 @@ public abstract class SceneManager implements LogicManager {
      */
     private void sceneExistenceCheck(String sceneName) {
         if (!scenes.containsKey(sceneName)) {
-            FastJEngine.error(
-                    CrashMessages.SceneError.errorMessage,
-                    new IllegalArgumentException("A scene with the name: \"" + sceneName + "\" hasn't been added!")
-            );
+            throw new IllegalArgumentException("A scene with the name: \"" + sceneName + "\" hasn't been added!");
         }
     }
 }

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -69,7 +69,7 @@ public abstract class SceneManager implements LogicManager {
 
     @Override
     public void processKeysDown() {
-        safeUpdate(currentScene.inputManager::fireKeysDown);
+        safeUpdate(currentScene.inputManager()::fireKeysDown);
     }
 
     /** Resets the logic manager. */
@@ -238,11 +238,11 @@ public abstract class SceneManager implements LogicManager {
         if (unloadCurrentScene) {
             currentScene.generalUnload(canvas);
         } else {
-            currentScene.inputManager.unload();
+            currentScene.inputManager().unload();
         }
 
         Scene nextScene = scenes.get(nextSceneName);
-        nextScene.inputManager.load();
+        nextScene.inputManager().load();
 
         if (!nextScene.isInitialized()) {
             nextScene.generalLoad(canvas);
@@ -347,8 +347,8 @@ public abstract class SceneManager implements LogicManager {
             initSceneCheck();
 
             canvas.render(
-                    currentScene.drawableManager.getGameObjects(),
-                    currentScene.drawableManager.getUIElements(),
+                    currentScene.drawableManager().getGameObjects(),
+                    currentScene.drawableManager().getUIElements(),
                     currentScene.getCamera()
             );
 

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -76,11 +76,9 @@ public abstract class SceneManager implements LogicManager {
     @Override
     public void reset() {
         for (Scene scene : scenes.values()) {
-            if (scene.isInitialized()) {
-                scene.generalUnload(FastJEngine.getCanvas());
-            }
             scene.reset();
         }
+
         scenes.clear();
     }
 

--- a/src/main/java/tech/fastj/systems/control/SceneManager.java
+++ b/src/main/java/tech/fastj/systems/control/SceneManager.java
@@ -76,7 +76,9 @@ public abstract class SceneManager implements LogicManager {
     @Override
     public void reset() {
         for (Scene scene : scenes.values()) {
-            scene.reset();
+            if (scene.isInitialized()) {
+                scene.reset();
+            }
         }
 
         scenes.clear();

--- a/src/main/java/tech/fastj/systems/control/SimpleManager.java
+++ b/src/main/java/tech/fastj/systems/control/SimpleManager.java
@@ -19,9 +19,19 @@ import java.util.List;
 public abstract class SimpleManager implements LogicManager, GameHandler {
 
     private final Camera camera;
-    /** Input manager instance for the simple manager -- it controls the scene's received events. */
+
+    /**
+     * Input manager instance for the simple manager -- it controls the scene's received events.
+     * @deprecated Public access to this field will be removed soon -- please use {@link GameHandler#inputManager()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public final InputManager inputManager;
-    /** Drawable manager instance for the simple manager -- it controls the scene's game objects and ui elements. */
+
+    /**
+     * Drawable manager instance for the simple manager -- it controls the scene's game objects and ui elements.
+     * @deprecated Public access to this field will be removed soon -- please use {@link GameHandler#drawableManager()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public final DrawableManager drawableManager;
 
     /** Initializes the contents of the {@code SimpleManager}. */

--- a/src/main/java/tech/fastj/systems/control/SimpleManager.java
+++ b/src/main/java/tech/fastj/systems/control/SimpleManager.java
@@ -87,7 +87,7 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
     @Override
     public void reset() {
         this.destroyBehaviorListeners();
-        drawableManager.destroyAllLists(this);
+        drawableManager.reset(this);
         this.clearBehaviorListeners();
         drawableManager.clearAllLists();
         inputManager.reset();

--- a/src/main/java/tech/fastj/systems/control/SimpleManager.java
+++ b/src/main/java/tech/fastj/systems/control/SimpleManager.java
@@ -6,9 +6,7 @@ import tech.fastj.graphics.display.FastJCanvas;
 
 import tech.fastj.input.InputManager;
 
-import tech.fastj.systems.behaviors.BehaviorHandler;
 import tech.fastj.systems.behaviors.BehaviorManager;
-import tech.fastj.systems.tags.TagHandler;
 
 import java.util.List;
 
@@ -18,7 +16,7 @@ import java.util.List;
  * @author Andrew Dey
  * @since 1.5.0
  */
-public abstract class SimpleManager implements LogicManager, BehaviorHandler, TagHandler<Drawable> {
+public abstract class SimpleManager implements LogicManager, GameHandler {
 
     private final Camera camera;
     /** Input manager instance for the simple manager -- it controls the scene's received events. */
@@ -61,6 +59,26 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
         this.updateBehaviorListeners();
     }
 
+    @Override
+    public InputManager inputManager() {
+        return inputManager;
+    }
+
+    @Override
+    public DrawableManager drawableManager() {
+        return drawableManager;
+    }
+
+    /**
+     * Gets the {@code Camera} of the manager.
+     *
+     * @return The manager's camera.
+     */
+    @Override
+    public Camera getCamera() {
+        return camera;
+    }
+
     /**
      * Renders the contents of the {@code DrawableManager} to the {@code FastJCanvas}.
      *
@@ -73,15 +91,6 @@ public abstract class SimpleManager implements LogicManager, BehaviorHandler, Ta
                 drawableManager.getUIElements(),
                 camera
         );
-    }
-
-    /**
-     * Gets the {@code Camera} of the manager.
-     *
-     * @return The manager's camera.
-     */
-    public Camera getCamera() {
-        return camera;
     }
 
     @Override

--- a/src/main/java/tech/fastj/systems/execution/FastJScheduledThreadPool.java
+++ b/src/main/java/tech/fastj/systems/execution/FastJScheduledThreadPool.java
@@ -1,0 +1,65 @@
+package tech.fastj.systems.execution;
+
+
+import tech.fastj.engine.FastJEngine;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+public class FastJScheduledThreadPool extends ScheduledThreadPoolExecutor {
+
+    private boolean shouldCloseOnError;
+
+    public FastJScheduledThreadPool(int corePoolSize) {
+        super(corePoolSize);
+    }
+
+    public FastJScheduledThreadPool(int corePoolSize, ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    public FastJScheduledThreadPool(int corePoolSize, RejectedExecutionHandler handler) {
+        super(corePoolSize, handler);
+    }
+
+    public FastJScheduledThreadPool(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+        super(corePoolSize, threadFactory, handler);
+    }
+
+    public void setShouldCloseOnError(boolean shouldCloseOnError) {
+        this.shouldCloseOnError = shouldCloseOnError;
+    }
+
+    @Override
+    protected void afterExecute(Runnable runnable, Throwable throwable) {
+        super.afterExecute(runnable, throwable);
+
+        if (throwable == null && runnable instanceof Future<?> && ((Future<?>) runnable).isDone()) {
+            try {
+                Future<?> future = (Future<?>) runnable;
+
+                if (future.isDone()) {
+                    future.get();
+                }
+            } catch (CancellationException exception) {
+                throwable = exception;
+            } catch (ExecutionException exception) {
+                throwable = exception.getCause();
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (throwable != null) {
+            FastJEngine.error("Error received while executing task", throwable);
+
+            if (shouldCloseOnError) {
+                FastJEngine.forceCloseGame();
+            }
+        }
+    }
+}

--- a/src/main/java/tech/fastj/systems/execution/RunLaterEvent.java
+++ b/src/main/java/tech/fastj/systems/execution/RunLaterEvent.java
@@ -1,8 +1,8 @@
 package tech.fastj.systems.execution;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 
-public class RunLaterEvent extends GameEvent {
+public class RunLaterEvent extends Event {
 
     private final Runnable runLater;
 

--- a/src/main/java/tech/fastj/systems/execution/RunLaterEvent.java
+++ b/src/main/java/tech/fastj/systems/execution/RunLaterEvent.java
@@ -1,0 +1,16 @@
+package tech.fastj.systems.execution;
+
+import tech.fastj.gameloop.event.GameEvent;
+
+public class RunLaterEvent extends GameEvent {
+
+    private final Runnable runLater;
+
+    public RunLaterEvent(Runnable runLater) {
+        this.runLater = runLater;
+    }
+
+    public Runnable getRunLater() {
+        return runLater;
+    }
+}

--- a/src/main/java/tech/fastj/systems/execution/RunLaterObserver.java
+++ b/src/main/java/tech/fastj/systems/execution/RunLaterObserver.java
@@ -1,0 +1,10 @@
+package tech.fastj.systems.execution;
+
+import tech.fastj.gameloop.event.GameEventObserver;
+
+public class RunLaterObserver implements GameEventObserver<RunLaterEvent> {
+    @Override
+    public void eventReceived(RunLaterEvent event) {
+        event.getRunLater().run();
+    }
+}

--- a/src/main/java/tech/fastj/systems/execution/RunLaterObserver.java
+++ b/src/main/java/tech/fastj/systems/execution/RunLaterObserver.java
@@ -1,8 +1,8 @@
 package tech.fastj.systems.execution;
 
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventObserver;
 
-public class RunLaterObserver implements GameEventObserver<RunLaterEvent> {
+public class RunLaterObserver implements EventObserver<RunLaterEvent> {
     @Override
     public void eventReceived(RunLaterEvent event) {
         event.getRunLater().run();

--- a/src/test/java/unittest/mock/gameloop/event/MockEvent.java
+++ b/src/test/java/unittest/mock/gameloop/event/MockEvent.java
@@ -1,6 +1,6 @@
 package unittest.mock.gameloop.event;
 
-import tech.fastj.gameloop.event.GameEvent;
+import tech.fastj.gameloop.event.Event;
 
-public class MockEvent extends GameEvent {
+public class MockEvent extends Event {
 }

--- a/src/test/java/unittest/mock/graphics/MockBoundariesDrawable.java
+++ b/src/test/java/unittest/mock/graphics/MockBoundariesDrawable.java
@@ -5,8 +5,7 @@ import tech.fastj.math.Maths;
 import tech.fastj.graphics.Drawable;
 import tech.fastj.graphics.util.DrawUtil;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 public class MockBoundariesDrawable extends Drawable {
 
@@ -23,10 +22,6 @@ public class MockBoundariesDrawable extends Drawable {
     }
 
     @Override
-    public void destroy(Scene origin) {
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
     }
 }

--- a/src/test/java/unittest/mock/graphics/MockDrawable.java
+++ b/src/test/java/unittest/mock/graphics/MockDrawable.java
@@ -2,15 +2,10 @@ package unittest.mock.graphics;
 
 import tech.fastj.graphics.Drawable;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 public class MockDrawable extends Drawable {
     @Override
-    public void destroy(Scene origin) {
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
     }
 }

--- a/src/test/java/unittest/mock/graphics/MockGameObject.java
+++ b/src/test/java/unittest/mock/graphics/MockGameObject.java
@@ -6,8 +6,6 @@ import tech.fastj.math.Transform2D;
 import tech.fastj.graphics.game.GameObject;
 
 import tech.fastj.systems.control.GameHandler;
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
 
 import java.awt.Graphics2D;
 

--- a/src/test/java/unittest/mock/graphics/MockGameObject.java
+++ b/src/test/java/unittest/mock/graphics/MockGameObject.java
@@ -5,6 +5,7 @@ import tech.fastj.math.Transform2D;
 
 import tech.fastj.graphics.game.GameObject;
 
+import tech.fastj.systems.control.GameHandler;
 import tech.fastj.systems.control.Scene;
 import tech.fastj.systems.control.SimpleManager;
 
@@ -12,11 +13,7 @@ import java.awt.Graphics2D;
 
 public class MockGameObject extends GameObject {
     @Override
-    public void destroy(Scene origin) {
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
+    public void destroy(GameHandler origin) {
     }
 
     @Override

--- a/src/test/java/unittest/mock/systems/tags/MockTaggableEntity.java
+++ b/src/test/java/unittest/mock/systems/tags/MockTaggableEntity.java
@@ -2,8 +2,7 @@ package unittest.mock.systems.tags;
 
 import tech.fastj.graphics.Drawable;
 
-import tech.fastj.systems.control.Scene;
-import tech.fastj.systems.control.SimpleManager;
+import tech.fastj.systems.control.GameHandler;
 
 import java.util.UUID;
 
@@ -14,12 +13,7 @@ public class MockTaggableEntity extends Drawable {
     }
 
     @Override
-    public void destroy(Scene origin) {
-        destroyTheRest(origin);
-    }
-
-    @Override
-    public void destroy(SimpleManager origin) {
-        destroyTheRest(origin);
+    public void destroy(GameHandler origin) {
+        super.destroyTheRest(origin);
     }
 }

--- a/src/test/java/unittest/testcases/engine/FastJEngineTests.java
+++ b/src/test/java/unittest/testcases/engine/FastJEngineTests.java
@@ -10,6 +10,7 @@ import tech.fastj.systems.control.SimpleManager;
 
 import unittest.EnvironmentHelper;
 import unittest.mock.systems.control.MockEmptySimpleManager;
+import tech.fastj.gameloop.CoreLoopState;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -38,10 +39,10 @@ class FastJEngineTests {
             FastJEngine.init("yeet", new SimpleManager() {
                 @Override
                 public void init(FastJCanvas canvas) {
-                    FastJEngine.runAfterUpdate(() -> {
+                    FastJEngine.runLater(() -> {
                         ranAfterUpdate.set(true);
                         FastJEngine.forceCloseGame();
-                    });
+                    }, CoreLoopState.FixedUpdate);
                 }
 
                 @Override
@@ -74,10 +75,10 @@ class FastJEngineTests {
             FastJEngine.init("yeet", new SimpleManager() {
                 @Override
                 public void init(FastJCanvas canvas) {
-                    FastJEngine.runAfterRender(() -> {
+                    FastJEngine.runLater(() -> {
                         ranAfterRender.set(true);
                         FastJEngine.forceCloseGame();
-                    });
+                    }, CoreLoopState.LateUpdate);
                 }
 
                 @Override

--- a/src/test/java/unittest/testcases/gameloop/GameLoopTests.java
+++ b/src/test/java/unittest/testcases/gameloop/GameLoopTests.java
@@ -4,8 +4,8 @@ import unittest.mock.gameloop.event.MockEvent;
 import tech.fastj.gameloop.CoreLoopState;
 import tech.fastj.gameloop.GameLoop;
 import tech.fastj.gameloop.GameLoopState;
-import tech.fastj.gameloop.event.GameEventHandler;
-import tech.fastj.gameloop.event.GameEventObserver;
+import tech.fastj.gameloop.event.EventHandler;
+import tech.fastj.gameloop.event.EventObserver;
 
 import java.util.Map;
 import java.util.Set;
@@ -96,11 +96,11 @@ class GameLoopTests {
         AtomicBoolean firedEvent = new AtomicBoolean();
         GameLoop gameLoop = new GameLoop((gl) -> shouldRemainOpen.get(), (gl) -> false);
 
-        GameEventObserver<MockEvent> gameEventObserver = (event) -> firedEvent.set(true);
-        gameLoop.addEventObserver(gameEventObserver, MockEvent.class);
-        assertEquals(gameEventObserver, gameLoop.getGameEventObservers(MockEvent.class).get(0));
-        assertEquals(1, gameLoop.getGameEventObservers(MockEvent.class).size());
-        gameLoop.removeEventObserver(gameEventObserver, MockEvent.class);
+        EventObserver<MockEvent> eventObserver = (event) -> firedEvent.set(true);
+        gameLoop.addEventObserver(eventObserver, MockEvent.class);
+        assertEquals(eventObserver, gameLoop.getEventObservers(MockEvent.class).get(0));
+        assertEquals(1, gameLoop.getEventObservers(MockEvent.class).size());
+        gameLoop.removeEventObserver(eventObserver, MockEvent.class);
 
         gameLoop.addGameLoopState(new GameLoopState(CoreLoopState.Update, 1, (gl, deltaTime) -> gameLoop.fireEvent(new MockEvent())));
         gameLoop.addGameLoopState(new GameLoopState(CoreLoopState.LateUpdate, 1, (gl, deltaTime) -> shouldRemainOpen.set(false)));
@@ -115,9 +115,9 @@ class GameLoopTests {
         AtomicBoolean firedEvent = new AtomicBoolean();
         GameLoop gameLoop = new GameLoop((gl) -> shouldRemainOpen.get(), (gl) -> false);
 
-        GameEventHandler<MockEvent, GameEventObserver<MockEvent>> gameEventHandler = (eventObservers, event) -> firedEvent.set(true);
-        gameLoop.addEventHandler(gameEventHandler, MockEvent.class);
-        assertEquals(gameEventHandler, gameLoop.getGameEventHandler(MockEvent.class));
+        EventHandler<MockEvent, EventObserver<MockEvent>> eventHandler = (eventObservers, event) -> firedEvent.set(true);
+        gameLoop.addEventHandler(eventHandler, MockEvent.class);
+        assertEquals(eventHandler, gameLoop.getEventHandler(MockEvent.class));
         gameLoop.removeEventHandler(MockEvent.class);
 
         gameLoop.addGameLoopState(new GameLoopState(CoreLoopState.Update, 1, (gl, deltaTime) -> gameLoop.fireEvent(new MockEvent())));
@@ -255,8 +255,8 @@ class GameLoopTests {
 
         gameLoop.reset();
 
-        assertEquals(0, gameLoop.getGameEventObservers(MockEvent.class).size(), "After resetting, there should be no event observers.");
-        assertNull(gameLoop.getGameEventHandler(MockEvent.class), "After resetting, there should be no event handler.");
+        assertEquals(0, gameLoop.getEventObservers(MockEvent.class).size(), "After resetting, there should be no event observers.");
+        assertNull(gameLoop.getEventHandler(MockEvent.class), "After resetting, there should be no event handler.");
         for (Set<GameLoopState> gameLoopStates : gameLoop.getGameLoopStates().values()) {
             assertEquals(0, gameLoopStates.size(), "After resetting, there should be no game loop states.");
         }
@@ -276,7 +276,7 @@ class GameLoopTests {
 
         gameLoop.clear();
 
-        assertEquals(0, gameLoop.getGameEventObservers(MockEvent.class).size(), "After clearing, there should be no event observers.");
-        assertNull(gameLoop.getGameEventHandler(MockEvent.class), "After clearing, there should be no event handler.");
+        assertEquals(0, gameLoop.getEventObservers(MockEvent.class).size(), "After clearing, there should be no event observers.");
+        assertNull(gameLoop.getEventHandler(MockEvent.class), "After clearing, there should be no event handler.");
     }
 }

--- a/src/test/java/unittest/testcases/systems/control/SceneManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SceneManagerTests.java
@@ -44,12 +44,12 @@ class SceneManagerTests {
 
         sceneManager.addScene(nameSettingScene1);
 
-        Throwable exception = assertThrows(IllegalStateException.class, () -> sceneManager.addScene(nameSettingScene2));
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> sceneManager.addScene(nameSettingScene2));
 
         String expectedExceptionMessage = "The scene name \"" + sceneName + "\" is already in use."
                 + System.lineSeparator()
                 + "Scenes added: [" + sceneName + "]";
-        assertEquals(expectedExceptionMessage, exception.getCause().getMessage(), "The exception message should match the expected exception message.");
+        assertEquals(expectedExceptionMessage, exception.getMessage(), "The exception message should match the expected exception message.");
     }
 
     @Test
@@ -67,10 +67,10 @@ class SceneManagerTests {
         SceneManager sceneManager = new MockSceneManager();
 
         String sceneName = "trying to get a scene with a scene name that doesn't exist should throw an exception";
-        Throwable exception = assertThrows(IllegalStateException.class, () -> sceneManager.getScene(sceneName));
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> sceneManager.getScene(sceneName));
 
         String expectedExceptionMessage = "A scene with the name: \"" + sceneName + "\" hasn't been added!";
-        assertEquals(expectedExceptionMessage, exception.getCause().getMessage(), "The exception message should match the expected exception message.");
+        assertEquals(expectedExceptionMessage, exception.getMessage(), "The exception message should match the expected exception message.");
     }
 
     @Test
@@ -100,10 +100,10 @@ class SceneManagerTests {
         SceneManager sceneManager = new MockSceneManager();
 
         String sceneName = "trying to remove a scene with a scene name that doesn't exist should throw an exception";
-        Throwable exception = assertThrows(IllegalStateException.class, () -> sceneManager.removeScene(sceneName));
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> sceneManager.removeScene(sceneName));
 
         String expectedExceptionMessage = "A scene with the name: \"" + sceneName + "\" hasn't been added!";
-        assertEquals(expectedExceptionMessage, exception.getCause().getMessage(), "The exception message should match the expected exception message.");
+        assertEquals(expectedExceptionMessage, exception.getMessage(), "The exception message should match the expected exception message.");
     }
 
     @Test
@@ -133,9 +133,9 @@ class SceneManagerTests {
         SceneManager sceneManager = new MockSceneManager();
 
         String sceneName = "trying to set the current scene with a scene name that doesn't exist should throw an exception";
-        Throwable exception = assertThrows(IllegalStateException.class, () -> sceneManager.setCurrentScene(sceneName));
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> sceneManager.setCurrentScene(sceneName));
 
         String expectedExceptionMessage = "A scene with the name: \"" + sceneName + "\" hasn't been added!";
-        assertEquals(expectedExceptionMessage, exception.getCause().getMessage(), "The exception message should match the expected exception message.");
+        assertEquals(expectedExceptionMessage, exception.getMessage(), "The exception message should match the expected exception message.");
     }
 }

--- a/src/test/java/unittest/testcases/systems/control/SceneTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SceneTests.java
@@ -39,7 +39,7 @@ class SceneTests {
 
         scene.getCamera().rotate(10f);
         GameObject gameObject = new MockGameObject();
-        scene.drawableManager.addGameObject(gameObject);
+        scene.drawableManager().addGameObject(gameObject);
         GameObject gameObject2 = new MockGameObject();
         scene.addBehaviorListener(gameObject2);
 

--- a/src/test/java/unittest/testcases/systems/control/SimpleManagerTests.java
+++ b/src/test/java/unittest/testcases/systems/control/SimpleManagerTests.java
@@ -29,7 +29,7 @@ class SimpleManagerTests {
 
         simpleManager.getCamera().rotate(10f);
         GameObject gameObject = new MockGameObject();
-        simpleManager.drawableManager.addGameObject(gameObject);
+        simpleManager.drawableManager().addGameObject(gameObject);
         GameObject gameObject2 = new MockGameObject();
         simpleManager.addBehaviorListener(gameObject2);
 


### PR DESCRIPTION
# The Rest of FastJ 1.7.0

## Additions
- Added timestamps to events
- joined `Scene` and `SimpleManager` with `GameHandler`, removing need for double implementations of destroy methods/ui constructors
- reduce throwing of `RejectedExecutionException` from `ManagedList`
- add custom thread pool to better handle exception throwing in FastJ


## Bug Fixes
- fixed issue where scenes needed to have all their game objects manually destroyed, and the scene manually uninitialized
- fixed issue where debug logging frame count printed nothing
- fixed many small bugs!


## Breaking Changes
- renamed everything with `GameEvent` to `Event`
- replaced buggy `runAfterUpdate` and `runAfterRender` with game loop friendly `runLater` in `FastJEngine.java`
- deprecated public access to `inputManager` and `drawableManager` in `Scene`/`SimpleManager`
    - replaced with accessor methods, instances were privated and deprecated for "removal" in a later FastJ release
- ensure default fps will be 60 if non-headless environment's monitor refresh rate is 0 or undefined (headless exception is thrown)
